### PR TITLE
Integrate trunk code checks into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trunk-io/trunk-action@v1
+        with:
+          arguments: fmt --ci
+      - uses: trunk-io/trunk-action@v1
+        with:
+          arguments: check --ci
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,7 @@
+version: 0.1
+
+lint:
+  enabled:
+    - clippy
+    - rustfmt
+    - taplo


### PR DESCRIPTION
## Summary
- add trunk configuration to enable clippy, rustfmt, and taplo
- run trunk fmt and check in CI before tests

## Testing
- `cargo test --all --locked`

------
https://chatgpt.com/codex/tasks/task_e_689e8550db008323932eec7478536537