### PR TITLE
Specify Trunk CLI version

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,5 +1,8 @@
 version: 0.1
 
+cli:
+  version: 1.5.2
+
 lint:
   enabled:
     - clippy


### PR DESCRIPTION
## Summary
- add CLI version to Trunk config to fix execution error

## Testing
- `cargo test`
- `trunk check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e89d098448323b8e687e131b4a5af