### PR TITLE
ci: install trunk manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: trunk-io/trunk-action@v1
-        with:
-          arguments: fmt --ci
-      - uses: trunk-io/trunk-action@v1
-        with:
-          arguments: check --ci
+      - name: Install Trunk
+        run: |
+          curl https://get.trunk.io -fsSL | bash
+          trunk install
+      - name: Run Trunk fmt
+        run: trunk fmt --ci
+      - name: Run Trunk check
+        run: trunk check --ci
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- install trunk via script before linting
- run trunk fmt and check explicitly

## Testing
- `trunk install` *(fails: Downloading Trunk 1.5.2... FAILED)*
- `cargo test --all --locked`

------
https://chatgpt.com/codex/tasks/task_e_689e8bde4ec083239782d552fc57f792