### PR TITLE
ci: add bridgecrew scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,17 @@ jobs:
         if: steps.detect_trunk.outputs.present == 'false'
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  bridgecrew:
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Bridgecrew scan
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          quiet: true
+
   test:
     runs-on: ubuntu-latest
     needs: lint


### PR DESCRIPTION
## Summary
- run Bridgecrew (Checkov) security scan in CI

## Testing
- `cargo test --all --locked`


------
https://chatgpt.com/codex/tasks/task_e_689e957391208323b0b836416a44b949