### PR TITLE
Organize typenum tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-test",
+ "typenum",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ criterion = { version = "0.5", default-features = false, features = ["async_toki
 toml = "0.8"
 serde_json = "1"
 canonical = { path = "../canonical" }
+typenum = "1.18"
 
 [[bench]]
 name = "rate_limit"

--- a/core/tests/arithmetic_ops.rs
+++ b/core/tests/arithmetic_ops.rs
@@ -1,0 +1,10 @@
+mod util;
+use util::{assert_binary_op, *};
+
+assert_binary_op!(add_1_1_is_2, Add, U1, U1, U2);
+assert_binary_op!(mul_2_2_is_4, Mul, U2, U2, U4);
+assert_binary_op!(pow_2_2_is_4, Pow, U2, U2, U4);
+assert_binary_op!(sub_2_1_is_1, Sub, U2, U1, U1);
+assert_binary_op!(min_2_1_is_1, Min, U2, U1, U1);
+assert_binary_op!(max_2_1_is_2, Max, U2, U1, U2);
+assert_binary_op!(gcd_6_4_is_2, Gcd, U6, U4, U2);

--- a/core/tests/bit_ops.rs
+++ b/core/tests/bit_ops.rs
@@ -1,0 +1,6 @@
+mod util;
+use util::{assert_binary_op, *};
+
+assert_binary_op!(bitand_0_1_is_0, BitAnd, U0, U1, U0);
+assert_binary_op!(bitor_0_1_is_1, BitOr, U0, U1, U1);
+assert_binary_op!(bitxor_0_1_is_1, BitXor, U0, U1, U1);

--- a/core/tests/comparison_ops.rs
+++ b/core/tests/comparison_ops.rs
@@ -1,0 +1,8 @@
+mod util;
+use util::*;
+
+#[test]
+fn cmp_1_2_is_less() {
+    type CmpResult = <U1 as typenum::Cmp<U2>>::Output;
+    assert_eq!(<CmpResult as Ord>::to_ordering(), Ordering::Less);
+}

--- a/core/tests/shift_ops.rs
+++ b/core/tests/shift_ops.rs
@@ -1,0 +1,5 @@
+mod util;
+use util::{assert_binary_op, *};
+
+assert_binary_op!(shl_1_by_1_is_2, Shl, U1, U1, U2);
+assert_binary_op!(shr_2_by_1_is_1, Shr, U2, U1, U1);

--- a/core/tests/util.rs
+++ b/core/tests/util.rs
@@ -1,0 +1,24 @@
+#![allow(unused_imports, dead_code, unused_macros)]
+
+pub use typenum::*;
+pub use core::ops::*;
+pub use core::cmp::Ordering;
+
+pub type U0 = UTerm;
+pub type U1 = UInt<U0, B1>;
+pub type U2 = UInt<U1, B0>;
+pub type U3 = UInt<U1, B1>;
+pub type U4 = UInt<U2, B0>;
+pub type U6 = UInt<U3, B0>;
+
+macro_rules! assert_binary_op {
+    ($name:ident, $trait:ident, $a:ty, $b:ty, $expected:ty) => {
+        #[test]
+        fn $name() {
+            type Result = <<$a as $trait<$b>>::Output as Same<$expected>>::Output;
+            assert_eq!(<Result as Unsigned>::to_u64(), <$expected as Unsigned>::to_u64());
+        }
+    };
+}
+
+pub(crate) use assert_binary_op;


### PR DESCRIPTION
## Summary
- split generated typenum test cases into modular integration tests
- share common type aliases and assert macro via `tests/util.rs`
- add `typenum` as a dev-dependency for `arb_core`

## Testing
- `cargo test -p arb_core`


------
https://chatgpt.com/codex/tasks/task_e_689e9de19430832386fba889b98fbf6a