### PR TITLE
Replace task channel with JoinSet

### DIFF
--- a/agents/src/adapter/mexc.rs
+++ b/agents/src/adapter/mexc.rs
@@ -8,8 +8,6 @@ use futures::SinkExt;
 use reqwest::Client;
 use serde_json::Value;
 use std::sync::Arc;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 
 use super::ExchangeAdapter;
@@ -72,7 +70,6 @@ pub struct MexcAdapter {
     cfg: &'static MexcConfig,
     _client: Client,
     chunk_size: usize,
-    _task_tx: mpsc::UnboundedSender<JoinHandle<()>>,
     symbols: Vec<String>,
     _books: Arc<DashMap<String, OrderBook>>,
     http_bucket: Arc<TokenBucket>,
@@ -84,7 +81,6 @@ impl MexcAdapter {
         cfg: &'static MexcConfig,
         client: Client,
         chunk_size: usize,
-        task_tx: mpsc::UnboundedSender<JoinHandle<()>>,
         symbols: Vec<String>,
     ) -> Self {
         let global_cfg = core::config::get();
@@ -92,7 +88,6 @@ impl MexcAdapter {
             cfg,
             _client: client,
             chunk_size,
-            _task_tx: task_tx,
             symbols,
             _books: Arc::new(DashMap::new()),
             http_bucket: Arc::new(TokenBucket::new(

--- a/ingestor/tests/partial_init.rs
+++ b/ingestor/tests/partial_init.rs
@@ -7,38 +7,37 @@ use std::{
         Arc,
     },
 };
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{sync::Mutex, task::JoinSet};
 
-async fn good_init(
-    task_tx: mpsc::UnboundedSender<JoinHandle<()>>,
-    counter: Arc<AtomicUsize>,
-) -> Result<()> {
+async fn good_init(task_set: Arc<Mutex<JoinSet<()>>>, counter: Arc<AtomicUsize>) -> Result<()> {
     let c = counter.clone();
-    let handle = tokio::spawn(async move {
-        c.fetch_add(1, Ordering::SeqCst);
-    });
-    let _ = task_tx.send(handle);
+    {
+        let mut set = task_set.lock().await;
+        set.spawn(async move {
+            c.fetch_add(1, Ordering::SeqCst);
+        });
+    }
     Ok(())
 }
 
-async fn bad_init(_task_tx: mpsc::UnboundedSender<JoinHandle<()>>) -> Result<()> {
+async fn bad_init(_task_set: Arc<Mutex<JoinSet<()>>>) -> Result<()> {
     Err(anyhow!("init failed"))
 }
 
 #[tokio::test]
 async fn continues_when_one_exchange_fails() {
-    let (task_tx, mut task_rx) = mpsc::unbounded_channel::<JoinHandle<()>>();
+    let task_set = Arc::new(Mutex::new(JoinSet::new()));
     let counter = Arc::new(AtomicUsize::new(0));
 
     let futures: Vec<Pin<Box<dyn Future<Output = (&'static str, Result<()>)> + Send>>> = vec![
         {
-            let tx = task_tx.clone();
+            let set = task_set.clone();
             let counter = counter.clone();
-            Box::pin(async move { ("ok", good_init(tx, counter).await) })
+            Box::pin(async move { ("ok", good_init(set, counter).await) })
         },
         {
-            let tx = task_tx.clone();
-            Box::pin(async move { ("bad", bad_init(tx).await) })
+            let set = task_set.clone();
+            Box::pin(async move { ("bad", bad_init(set).await) })
         },
     ];
 
@@ -64,9 +63,11 @@ async fn continues_when_one_exchange_fails() {
     assert_eq!(ok, 1);
     assert_eq!(err, 1);
 
-    drop(task_tx);
-    while let Some(handle) = task_rx.recv().await {
-        handle.await.unwrap();
+    {
+        let mut set = task_set.lock().await;
+        while let Some(res) = set.join_next().await {
+            res.unwrap();
+        }
     }
 
     assert_eq!(counter.load(Ordering::SeqCst), 1);


### PR DESCRIPTION
## Summary
- use a `JoinSet` instead of an mpsc channel to track background tasks
- spawn adapter and consumer tasks directly into the `JoinSet`
- await all tasks via `JoinSet::join_next` for error logging

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689ec98aa9588323bb5067fb418ab4a0