### PR TITLE
Add adapter registry and dynamic exchange configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "futures",
  "metrics",
  "metrics-util",
+ "once_cell",
  "rand 0.8.5",
  "reqwest",
  "rustls 0.21.12",

--- a/agents/Cargo.toml
+++ b/agents/Cargo.toml
@@ -20,6 +20,7 @@ metrics = "0.24"
 rustls = "0.21"
 serde_json = "1"
 dashmap = "5"
+once_cell = "1"
 
 [features]
 default = []

--- a/agents/src/registry.rs
+++ b/agents/src/registry.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use arb_core as core;
+use dashmap::DashMap;
+use futures::future::BoxFuture;
+use reqwest::Client;
+use rustls::ClientConfig;
+use tokio::sync::mpsc;
+
+use crate::TaskSet;
+
+pub type AdapterFactory = Arc<
+    dyn Fn(
+            &'static core::config::Config,
+            &core::config::ExchangeConfig,
+            Client,
+            TaskSet,
+            Arc<DashMap<String, mpsc::Sender<core::events::StreamMessage<'static>>>>,
+            Arc<ClientConfig>,
+            usize,
+        ) -> BoxFuture<'static, Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>>>
+        + Send
+        + Sync,
+>;
+
+use once_cell::sync::Lazy;
+
+static REGISTRY: Lazy<DashMap<&'static str, AdapterFactory>> = Lazy::new(|| DashMap::new());
+
+pub fn register_adapter(id: &'static str, factory: AdapterFactory) {
+    REGISTRY.insert(id, factory);
+}
+
+pub fn get_adapter(id: &str) -> Option<AdapterFactory> {
+    REGISTRY.get(id).map(|f| f.value().clone())
+}

--- a/agents/tests/network.rs
+++ b/agents/tests/network.rs
@@ -57,6 +57,7 @@ async fn run_ws_emits_event() {
 }
 
 static TEST_CFG: BinanceConfig = BinanceConfig {
+    id: "test",
     name: "Test",
     info_url: "http://localhost/",
     ws_base: "wss://127.0.0.1:1/",

--- a/core/tests/config.rs
+++ b/core/tests/config.rs
@@ -24,6 +24,7 @@ fn empty_spot_symbols_fails() {
         },
         ca_bundle: None,
         cert_pins: Vec::new(),
+        exchanges: Vec::new(),
     };
     assert!(cfg.validate().is_err());
 }
@@ -51,6 +52,7 @@ fn empty_futures_symbols_fails() {
         },
         ca_bundle: None,
         cert_pins: Vec::new(),
+        exchanges: Vec::new(),
     };
     assert!(cfg.validate().is_err());
 }
@@ -78,6 +80,7 @@ fn invalid_chunk_size_fails() {
         },
         ca_bundle: None,
         cert_pins: Vec::new(),
+        exchanges: Vec::new(),
     };
     assert!(cfg.validate().is_err());
 }
@@ -105,6 +108,7 @@ fn invalid_event_buffer_size_fails() {
         },
         ca_bundle: None,
         cert_pins: Vec::new(),
+        exchanges: Vec::new(),
     };
     assert!(cfg.validate().is_err());
 }


### PR DESCRIPTION
## Summary
- create central registry mapping exchange IDs to adapter factories
- use registry in `spawn_adapters` driven by config exchange list
- adapters self-register with the registry
- configuration accepts exchange IDs with symbol settings

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7afc313c832399a1b714549773ea