### PR TITLE
Extend MdEvent with additional market data variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ version = "0.1.0"
 dependencies = [
  "arb_core",
  "rust_decimal",
+ "serde",
  "serde_json",
 ]
 

--- a/canonical/Cargo.toml
+++ b/canonical/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 arb_core = { path = "../core" }
 rust_decimal = "1"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
## Summary
- Add MiniTicker, BookTicker, Kline, DepthL2Update, DepthSnapshot, and AvgPrice structs with serde support
- Wire `arb_core` event conversions into MdEvent for new variants
- Test round-trip serialization and field mapping for each new market data type

## Testing
- `cargo test -p canonical`

------
https://chatgpt.com/codex/tasks/task_e_689f851aebec8323a700134ac4cb2f89