### PR TITLE
Add LATOKEN adapter and stream configuration

### DIFF
--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -25,3 +25,4 @@ pub trait ExchangeAdapter {
 pub mod binance;
 pub mod mexc;
 pub mod gateio;
+pub mod latoken;

--- a/agents/src/lib.rs
+++ b/agents/src/lib.rs
@@ -16,6 +16,7 @@ pub use adapter::binance::{
     fetch_symbols as fetch_binance_symbols, BinanceAdapter, BINANCE_EXCHANGES,
 };
 pub use adapter::mexc::{fetch_symbols, MexcAdapter, MEXC_EXCHANGES};
+pub use adapter::latoken::{fetch_symbols as fetch_latoken_symbols, LatokenAdapter, LATOKEN_EXCHANGES};
 pub use adapter::ExchangeAdapter;
 
 /// Shared task set type for spawning and tracking asynchronous tasks.
@@ -105,6 +106,7 @@ pub async fn spawn_adapters(
 ) -> Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>> {
     adapter::binance::register();
     adapter::mexc::register();
+    adapter::latoken::register();
 
     let mut receivers = Vec::new();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,6 +60,11 @@ static GATEIO_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     from_slice(&mut data).expect("invalid gateio stream configuration")
 });
 
+static LATOKEN_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
+    let mut data = include_bytes!("../../streams_latoken.json").to_vec();
+    from_slice(&mut data).expect("invalid latoken stream configuration")
+});
+
 /// Returns the default stream configuration.
 pub fn default_stream_config() -> &'static StreamConfig {
     &STREAM_CONFIG
@@ -72,6 +77,7 @@ pub fn stream_config_for_exchange(name: &str) -> &'static StreamConfig {
         "Binance Futures" | "Binance Delivery" => &FUTURES_STREAM_CONFIG,
         "Binance Options" => &OPTIONS_STREAM_CONFIG,
         "Gate.io Spot" => &GATEIO_STREAM_CONFIG,
+        "LATOKEN" => &LATOKEN_STREAM_CONFIG,
         _ => default_stream_config(),
     }
 }

--- a/streams_latoken.json
+++ b/streams_latoken.json
@@ -1,0 +1,8 @@
+{
+  "global": [],
+  "per_symbol": [
+    "trades",
+    "ticker",
+    "orderbook"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement LATOKEN exchange adapter with symbol fetching from ticker API
- register LATOKEN adapter and expose from library
- add LATOKEN-specific stream configuration

## Testing
- `cargo build -q`
- `cargo test` *(fails: no variant or associated item named `Book` found for enum `MdEvent` in core tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ed36f44832394fa1a14fa93e762