### PR TITLE
Add CoinEx adapter with spot and perpetual support

### DIFF
--- a/agents/src/adapter/coinex.rs
+++ b/agents/src/adapter/coinex.rs
@@ -1,0 +1,309 @@
+use anyhow::{anyhow, Result};
+use arb_core as core;
+use async_trait::async_trait;
+use core::rate_limit::TokenBucket;
+use core::{chunk_streams_with_config, stream_config_for_exchange, OrderBook};
+use dashmap::DashMap;
+use futures::{SinkExt, StreamExt};
+use reqwest::Client;
+use serde_json::Value;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::{
+    signal,
+    task::JoinHandle,
+    time::{sleep, Duration},
+};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+
+use super::ExchangeAdapter;
+use crate::{registry, ChannelRegistry, TaskSet};
+use futures::future::BoxFuture;
+use std::sync::Once;
+use tokio::sync::mpsc;
+use tracing::error;
+
+pub struct CoinexConfig {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub ws_base: &'static str,
+}
+
+pub const COINEX_EXCHANGES: &[CoinexConfig] = &[
+    CoinexConfig {
+        id: "coinex_spot",
+        name: "CoinEx Spot",
+        ws_base: "wss://socket.coinex.com/",
+    },
+    CoinexConfig {
+        id: "coinex_perpetual",
+        name: "CoinEx Perpetual",
+        ws_base: "wss://perpetual.coinex.com/",
+    },
+];
+
+const SPOT_INFO_URL: &str = "https://api.coinex.com/v1/market/info";
+const PERP_INFO_URL: &str = "https://api.coinex.com/perpetual/v1/market/list";
+
+pub async fn fetch_symbols() -> Result<Vec<String>> {
+    let client = Client::new();
+    let mut symbols: Vec<String> = Vec::new();
+
+    let mut page = 1;
+    let limit = 100;
+    loop {
+        let url = format!("{SPOT_INFO_URL}?limit={limit}&page={page}");
+        let resp = client.get(&url).send().await?.error_for_status()?;
+        let data: Value = resp.json().await?;
+        let obj = data
+            .get("data")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| anyhow!("missing data object"))?;
+        let count = obj.len();
+        symbols.extend(obj.keys().cloned());
+        if count < limit {
+            break;
+        }
+        page += 1;
+    }
+
+    let mut page = 1;
+    loop {
+        let url = format!("{PERP_INFO_URL}?limit={limit}&page={page}");
+        let resp = client.get(&url).send().await?.error_for_status()?;
+        let data: Value = resp.json().await?;
+        let arr = data
+            .get("data")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| anyhow!("missing data array"))?;
+        let count = arr.len();
+        for item in arr {
+            if let Some(sym) = item.get("name").and_then(|v| v.as_str()) {
+                symbols.push(sym.to_string());
+            }
+        }
+        if count < limit {
+            break;
+        }
+        page += 1;
+    }
+
+    symbols.sort();
+    symbols.dedup();
+    Ok(symbols)
+}
+
+static REGISTER: Once = Once::new();
+
+pub fn register() {
+    REGISTER.call_once(|| {
+        for exch in COINEX_EXCHANGES {
+            let cfg_ref: &'static CoinexConfig = exch;
+            registry::register_adapter(
+                cfg_ref.id,
+                Arc::new(
+                    move |global_cfg: &'static core::config::Config,
+                          exchange_cfg: &core::config::ExchangeConfig,
+                          client: Client,
+                          task_set: TaskSet,
+                          channels: ChannelRegistry,
+                          _tls_config: Arc<rustls::ClientConfig>|
+                          -> BoxFuture<
+                        'static,
+                        Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>>,
+                    > {
+                        let cfg = cfg_ref;
+                        let initial_symbols = exchange_cfg.symbols.clone();
+                        Box::pin(async move {
+                            let mut symbols = initial_symbols;
+                            if symbols.is_empty() {
+                                symbols = fetch_symbols().await?;
+                            }
+
+                            let mut receivers = Vec::new();
+                            for symbol in &symbols {
+                                let key = format!("{}:{}", cfg.name, symbol);
+                                let (_, rx) = channels.get_or_create(&key);
+                                if let Some(rx) = rx {
+                                    receivers.push(rx);
+                                }
+                            }
+
+                            let adapter = CoinexAdapter::new(
+                                cfg,
+                                client.clone(),
+                                global_cfg.chunk_size,
+                                symbols,
+                            );
+
+                            {
+                                let mut set = task_set.lock().await;
+                                set.spawn(async move {
+                                    let mut adapter = adapter;
+                                    if let Err(e) = adapter.run().await {
+                                        error!("Failed to run adapter: {}", e);
+                                    }
+                                });
+                            }
+
+                            Ok(receivers)
+                        })
+                    },
+                ),
+            );
+        }
+    });
+}
+
+pub struct CoinexAdapter {
+    cfg: &'static CoinexConfig,
+    _client: Client,
+    chunk_size: usize,
+    symbols: Vec<String>,
+    _books: Arc<DashMap<String, OrderBook>>,
+    http_bucket: Arc<TokenBucket>,
+    ws_bucket: Arc<TokenBucket>,
+    tasks: Vec<JoinHandle<Result<()>>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl CoinexAdapter {
+    pub fn new(
+        cfg: &'static CoinexConfig,
+        client: Client,
+        chunk_size: usize,
+        symbols: Vec<String>,
+    ) -> Self {
+        let global_cfg = core::config::get();
+        Self {
+            cfg,
+            _client: client,
+            chunk_size,
+            symbols,
+            _books: Arc::new(DashMap::new()),
+            http_bucket: Arc::new(TokenBucket::new(
+                global_cfg.http_burst,
+                global_cfg.http_refill_per_sec,
+                std::time::Duration::from_secs(1),
+            )),
+            ws_bucket: Arc::new(TokenBucket::new(
+                global_cfg.ws_burst,
+                global_cfg.ws_refill_per_sec,
+                std::time::Duration::from_secs(1),
+            )),
+            tasks: Vec::new(),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[async_trait]
+impl ExchangeAdapter for CoinexAdapter {
+    async fn subscribe(&mut self) -> Result<()> {
+        let symbol_refs: Vec<&str> = self.symbols.iter().map(|s| s.as_str()).collect();
+        let cfg = stream_config_for_exchange(self.cfg.name);
+        let chunks = chunk_streams_with_config(&symbol_refs, self.chunk_size, cfg);
+
+        for chunk in chunks {
+            let symbols = chunk.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+            let ws_url = self.cfg.ws_base.to_string();
+            let ws_bucket = self.ws_bucket.clone();
+            let shutdown = self.shutdown.clone();
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    ws_bucket.acquire(1).await;
+                    match connect_async(&ws_url).await {
+                        Ok((mut ws, _)) => {
+                            for symbol in &symbols {
+                                let sub = serde_json::json!({
+                                    "method": "depth.subscribe",
+                                    "params": [symbol, 50, "0"],
+                                    "id": 0,
+                                });
+                                let _ = ws.send(Message::Text(sub.to_string())).await;
+                                let sub = serde_json::json!({
+                                    "method": "deals.subscribe",
+                                    "params": [symbol],
+                                    "id": 0,
+                                });
+                                let _ = ws.send(Message::Text(sub.to_string())).await;
+                                let sub = serde_json::json!({
+                                    "method": "state.subscribe",
+                                    "params": [symbol],
+                                    "id": 0,
+                                });
+                                let _ = ws.send(Message::Text(sub.to_string())).await;
+                            }
+                            loop {
+                                tokio::select! {
+                                    msg = ws.next() => {
+                                        match msg {
+                                            Some(Ok(Message::Ping(p))) => {
+                                                ws.send(Message::Pong(p)).await.map_err(|e| {
+                                                    tracing::error!("coinex ws pong error: {}", e);
+                                                    e
+                                                })?;
+                                            },
+                                            Some(Ok(Message::Close(_))) | None => { break; },
+                                            Some(Ok(_)) => {},
+                                            Some(Err(e)) => { tracing::warn!("coinex ws error: {}", e); break; },
+                                        }
+                                    }
+                                    _ = async {
+                                        while !shutdown.load(Ordering::Relaxed) {
+                                            sleep(Duration::from_secs(1)).await;
+                                        }
+                                    } => {
+                                        let _ = ws.close(None).await;
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("coinex connect error: {}", e);
+                        }
+                    }
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    sleep(Duration::from_secs(5)).await;
+                }
+                Ok::<(), anyhow::Error>(())
+            });
+            self.tasks.push(handle);
+        }
+        Ok(())
+    }
+
+    async fn run(&mut self) -> Result<()> {
+        self.subscribe().await?;
+
+        let _ = signal::ctrl_c().await;
+        self.shutdown.store(true, Ordering::SeqCst);
+
+        for handle in self.tasks.drain(..) {
+            let _ = handle.await;
+        }
+        Ok(())
+    }
+
+    async fn heartbeat(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn auth(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn backfill(&mut self) -> Result<()> {
+        self.http_bucket.acquire(1).await;
+        Ok(())
+    }
+}

--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -23,5 +23,6 @@ pub trait ExchangeAdapter {
 }
 
 pub mod binance;
-pub mod mexc;
+pub mod coinex;
 pub mod gateio;
+pub mod mexc;

--- a/agents/src/lib.rs
+++ b/agents/src/lib.rs
@@ -105,6 +105,7 @@ pub async fn spawn_adapters(
 ) -> Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>> {
     adapter::binance::register();
     adapter::mexc::register();
+    adapter::coinex::register();
 
     let mut receivers = Vec::new();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,6 +60,16 @@ static GATEIO_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     from_slice(&mut data).expect("invalid gateio stream configuration")
 });
 
+static COINEX_SPOT_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
+    let mut data = include_bytes!("../../streams_coinex_spot.json").to_vec();
+    from_slice(&mut data).expect("invalid coinex spot stream configuration")
+});
+
+static COINEX_PERPETUAL_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
+    let mut data = include_bytes!("../../streams_coinex_perpetual.json").to_vec();
+    from_slice(&mut data).expect("invalid coinex perpetual stream configuration")
+});
+
 /// Returns the default stream configuration.
 pub fn default_stream_config() -> &'static StreamConfig {
     &STREAM_CONFIG
@@ -72,6 +82,8 @@ pub fn stream_config_for_exchange(name: &str) -> &'static StreamConfig {
         "Binance Futures" | "Binance Delivery" => &FUTURES_STREAM_CONFIG,
         "Binance Options" => &OPTIONS_STREAM_CONFIG,
         "Gate.io Spot" => &GATEIO_STREAM_CONFIG,
+        "CoinEx Spot" => &COINEX_SPOT_STREAM_CONFIG,
+        "CoinEx Perpetual" => &COINEX_PERPETUAL_STREAM_CONFIG,
         _ => default_stream_config(),
     }
 }

--- a/streams_coinex_perpetual.json
+++ b/streams_coinex_perpetual.json
@@ -1,0 +1,8 @@
+{
+  "global": [],
+  "per_symbol": [
+    "depth.subscribe",
+    "deals.subscribe",
+    "state.subscribe"
+  ]
+}

--- a/streams_coinex_spot.json
+++ b/streams_coinex_spot.json
@@ -1,0 +1,8 @@
+{
+  "global": [],
+  "per_symbol": [
+    "depth.subscribe",
+    "deals.subscribe",
+    "state.subscribe"
+  ]
+}


### PR DESCRIPTION
## Summary
- implement CoinEx exchange adapter with spot and perpetual markets
- add stream configs for CoinEx book, trade, and ticker channels
- wire CoinEx into adapter registry and stream configuration

## Testing
- `cargo test` *(fails: no variant or associated item named `Book` found in `MdEvent`)*

------
https://chatgpt.com/codex/tasks/task_e_689f8eccbeb083238904fba247d9142c