### PR TITLE
Add BitMart exchange adapter

### DIFF
--- a/agents/src/adapter/bitmart.rs
+++ b/agents/src/adapter/bitmart.rs
@@ -1,0 +1,211 @@
+use anyhow::{anyhow, Result};
+use arb_core as core;
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use reqwest::Client;
+use serde_json::Value;
+use std::sync::{Arc, Once};
+use tokio::sync::mpsc;
+use tracing::error;
+
+use super::ExchangeAdapter;
+use crate::{registry, ChannelRegistry, TaskSet};
+
+/// Configuration for a single BitMart exchange endpoint.
+pub struct BitmartConfig {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub spot_url: &'static str,
+    pub contract_url: &'static str,
+}
+
+/// All BitMart exchanges supported by this adapter.
+pub const BITMART_EXCHANGES: &[BitmartConfig] = &[
+    BitmartConfig {
+        id: "bitmart_spot",
+        name: "BitMart Spot",
+        spot_url: "https://api-cloud.bitmart.com/spot/v1/symbols/details",
+        contract_url: "https://api-cloud.bitmart.com/contract/v1/ifcontract/contracts",
+    },
+    BitmartConfig {
+        id: "bitmart_contract",
+        name: "BitMart Contract",
+        spot_url: "https://api-cloud.bitmart.com/spot/v1/symbols/details",
+        contract_url: "https://api-cloud.bitmart.com/contract/v1/ifcontract/contracts",
+    },
+];
+
+/// Retrieve all spot trading symbols from BitMart.
+pub async fn fetch_spot_symbols(url: &str) -> Result<Vec<String>> {
+    let resp = Client::new()
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    let data: Value = resp.json().await?;
+    let arr = data
+        .get("data")
+        .and_then(|v| v.get("symbols"))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("missing symbols array"))?;
+
+    let mut result: Vec<String> = arr
+        .iter()
+        .filter_map(|s| {
+            let tradable = s
+                .get("trade_status")
+                .and_then(|v| v.as_str())
+                .map(|st| st.eq_ignore_ascii_case("trading"))
+                .unwrap_or(false);
+            if tradable {
+                s.get("symbol")
+                    .and_then(|v| v.as_str())
+                    .map(|v| v.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    result.sort();
+    result.dedup();
+    Ok(result)
+}
+
+/// Retrieve all contract trading symbols from BitMart.
+pub async fn fetch_contract_symbols(url: &str) -> Result<Vec<String>> {
+    let resp = Client::new()
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?;
+    let data: Value = resp.json().await?;
+    let arr = data
+        .get("data")
+        .and_then(|v| v.get("symbols").or_else(|| v.get("contracts")))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("missing contracts array"))?;
+
+    let mut result: Vec<String> = arr
+        .iter()
+        .filter_map(|s| {
+            s.get("symbol")
+                .and_then(|v| v.as_str())
+                .map(|v| v.to_string())
+        })
+        .collect();
+    result.sort();
+    result.dedup();
+    Ok(result)
+}
+
+/// Fetch and merge spot and contract symbols.
+pub async fn fetch_symbols(cfg: &BitmartConfig) -> Result<Vec<String>> {
+    let mut symbols = fetch_spot_symbols(cfg.spot_url).await?;
+    let mut contracts = fetch_contract_symbols(cfg.contract_url).await?;
+    symbols.append(&mut contracts);
+    symbols.sort();
+    symbols.dedup();
+    Ok(symbols)
+}
+
+static REGISTER: Once = Once::new();
+
+pub fn register() {
+    REGISTER.call_once(|| {
+        for exch in BITMART_EXCHANGES {
+            let cfg_ref: &'static BitmartConfig = exch;
+            registry::register_adapter(
+                cfg_ref.id,
+                Arc::new(
+                    move |_global_cfg: &'static core::config::Config,
+                          exchange_cfg: &core::config::ExchangeConfig,
+                          client: Client,
+                          task_set: TaskSet,
+                          channels: ChannelRegistry,
+                          _tls_config: Arc<rustls::ClientConfig>|
+                          -> BoxFuture<
+                        'static,
+                        Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>>,
+                    > {
+                        let cfg = cfg_ref;
+                        let initial_symbols = exchange_cfg.symbols.clone();
+                        Box::pin(async move {
+                            let mut symbols = initial_symbols;
+                            if symbols.is_empty() {
+                                symbols = fetch_symbols(cfg).await?;
+                            }
+
+                            let mut receivers = Vec::new();
+                            for symbol in &symbols {
+                                let key = format!("{}:{}", cfg.name, symbol);
+                                let (_, rx) = channels.get_or_create(&key);
+                                if let Some(rx) = rx {
+                                    receivers.push(rx);
+                                }
+                            }
+
+                            let adapter = BitmartAdapter::new(cfg, client.clone(), symbols);
+
+                            {
+                                let mut set = task_set.lock().await;
+                                set.spawn(async move {
+                                    let mut adapter = adapter;
+                                    if let Err(e) = adapter.run().await {
+                                        error!("Failed to run adapter: {}", e);
+                                    }
+                                });
+                            }
+
+                            Ok(receivers)
+                        })
+                    },
+                ),
+            );
+        }
+    });
+}
+
+/// Adapter implementing the `ExchangeAdapter` trait for BitMart.
+pub struct BitmartAdapter {
+    cfg: &'static BitmartConfig,
+    _client: Client,
+    symbols: Vec<String>,
+}
+
+impl BitmartAdapter {
+    pub fn new(cfg: &'static BitmartConfig, client: Client, symbols: Vec<String>) -> Self {
+        Self {
+            cfg,
+            _client: client,
+            symbols,
+        }
+    }
+}
+
+#[async_trait]
+impl ExchangeAdapter for BitmartAdapter {
+    async fn subscribe(&mut self) -> Result<()> {
+        // Subscription logic will be implemented later.
+        Ok(())
+    }
+
+    async fn run(&mut self) -> Result<()> {
+        self.auth().await?;
+       self.backfill().await?;
+       self.subscribe().await?;
+        self.heartbeat().await?;
+        Ok(())
+    }
+
+    async fn heartbeat(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn auth(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn backfill(&mut self) -> Result<()> {
+        Ok(())
+    }
+}

--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -25,3 +25,4 @@ pub trait ExchangeAdapter {
 pub mod binance;
 pub mod mexc;
 pub mod gateio;
+pub mod bitmart;

--- a/agents/src/lib.rs
+++ b/agents/src/lib.rs
@@ -16,6 +16,9 @@ pub use adapter::binance::{
     fetch_symbols as fetch_binance_symbols, BinanceAdapter, BINANCE_EXCHANGES,
 };
 pub use adapter::mexc::{fetch_symbols, MexcAdapter, MEXC_EXCHANGES};
+pub use adapter::bitmart::{
+    fetch_symbols as fetch_bitmart_symbols, BitmartAdapter, BITMART_EXCHANGES,
+};
 pub use adapter::ExchangeAdapter;
 
 /// Shared task set type for spawning and tracking asynchronous tasks.
@@ -105,6 +108,7 @@ pub async fn spawn_adapters(
 ) -> Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>> {
     adapter::binance::register();
     adapter::mexc::register();
+    adapter::bitmart::register();
 
     let mut receivers = Vec::new();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,6 +60,16 @@ static GATEIO_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     from_slice(&mut data).expect("invalid gateio stream configuration")
 });
 
+static BITMART_SPOT_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
+    let mut data = include_bytes!("../../streams_bitmart_spot.json").to_vec();
+    from_slice(&mut data).expect("invalid bitmart spot stream configuration")
+});
+
+static BITMART_CONTRACT_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
+    let mut data = include_bytes!("../../streams_bitmart_contract.json").to_vec();
+    from_slice(&mut data).expect("invalid bitmart contract stream configuration")
+});
+
 /// Returns the default stream configuration.
 pub fn default_stream_config() -> &'static StreamConfig {
     &STREAM_CONFIG
@@ -72,6 +82,8 @@ pub fn stream_config_for_exchange(name: &str) -> &'static StreamConfig {
         "Binance Futures" | "Binance Delivery" => &FUTURES_STREAM_CONFIG,
         "Binance Options" => &OPTIONS_STREAM_CONFIG,
         "Gate.io Spot" => &GATEIO_STREAM_CONFIG,
+        "BitMart Spot" => &BITMART_SPOT_STREAM_CONFIG,
+        "BitMart Contract" => &BITMART_CONTRACT_STREAM_CONFIG,
         _ => default_stream_config(),
     }
 }

--- a/streams_bitmart_contract.json
+++ b/streams_bitmart_contract.json
@@ -1,0 +1,19 @@
+{
+  "global": [],
+  "per_symbol": [
+    "ticker",
+    "kline_1m",
+    "kline_5m",
+    "kline_15m",
+    "kline_30m",
+    "kline_1h",
+    "kline_4h",
+    "kline_1d",
+    "kline_1w",
+    "kline_1M",
+    "depth5",
+    "depth20",
+    "trade",
+    "funding_rate"
+  ]
+}

--- a/streams_bitmart_spot.json
+++ b/streams_bitmart_spot.json
@@ -1,0 +1,18 @@
+{
+  "global": [],
+  "per_symbol": [
+    "ticker",
+    "kline_1m",
+    "kline_5m",
+    "kline_15m",
+    "kline_30m",
+    "kline_1h",
+    "kline_4h",
+    "kline_1d",
+    "kline_1w",
+    "kline_1M",
+    "depth5",
+    "depth20",
+    "trade"
+  ]
+}


### PR DESCRIPTION
## Summary
- add BitMart exchange adapter with spot and contract symbol discovery
- expose adapter in registry and provide stream configurations

## Testing
- `cargo test` *(fails: `MdEvent::Book` variant not found in core tests)*
- `cargo test -p agents`


------
https://chatgpt.com/codex/tasks/task_e_689f8ecd7abc8323a12e5c93b2346cb8