### PR TITLE
Add XT exchange adapter with combined symbol discovery

### DIFF
--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -25,3 +25,4 @@ pub trait ExchangeAdapter {
 pub mod binance;
 pub mod mexc;
 pub mod gateio;
+pub mod xt;

--- a/agents/src/adapter/xt.rs
+++ b/agents/src/adapter/xt.rs
@@ -1,0 +1,276 @@
+use anyhow::{Result};
+use arb_core as core;
+use async_trait::async_trait;
+use core::rate_limit::TokenBucket;
+use core::{chunk_streams_with_config, stream_config_for_exchange, OrderBook};
+use dashmap::DashMap;
+use futures::{SinkExt, StreamExt};
+use reqwest::Client;
+use serde_json::Value;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use tokio::{
+    signal,
+    task::JoinHandle,
+    time::{sleep, Duration},
+};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
+
+use super::ExchangeAdapter;
+use crate::{registry, ChannelRegistry, TaskSet};
+use futures::future::BoxFuture;
+use std::sync::Once;
+use tokio::sync::mpsc;
+use tracing::error;
+
+pub const SPOT_SYMBOL_URL: &str = "https://api.xt.com/data/api/v4/public/symbol";
+pub const FUTURES_SYMBOL_URL: &str = "https://futures.xt.com/api/v4/public/symbol";
+
+/// Configuration for a single XT exchange endpoint.
+pub struct XtConfig {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub ws_base: &'static str,
+}
+
+/// All XT exchanges supported by this adapter.
+pub const XT_EXCHANGES: &[XtConfig] = &[
+    XtConfig {
+        id: "xt_spot",
+        name: "XT Spot",
+        ws_base: "wss://stream.xt.com/ws?streams=",
+    },
+    XtConfig {
+        id: "xt_futures",
+        name: "XT Futures",
+        ws_base: "wss://stream.xt.com/futures/ws?streams=",
+    },
+];
+
+/// Recursively extract symbol strings from arbitrary JSON structures.
+fn extract_symbols(val: &Value, out: &mut Vec<String>) {
+    match val {
+        Value::Array(arr) => {
+            for v in arr {
+                extract_symbols(v, out);
+            }
+        }
+        Value::Object(map) => {
+            for (k, v) in map {
+                if (k == "symbol" || k == "s" || k == "id" || k == "pair") && v.is_string() {
+                    if let Some(s) = v.as_str() {
+                        out.push(s.to_string());
+                    }
+                }
+                extract_symbols(v, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Retrieve all trading symbols from both the spot and futures REST endpoints.
+pub async fn fetch_symbols() -> Result<Vec<String>> {
+    let client = Client::new();
+    let mut symbols = Vec::new();
+    for url in [SPOT_SYMBOL_URL, FUTURES_SYMBOL_URL] {
+        if let Ok(resp) = client.get(url).send().await {
+            if let Ok(resp) = resp.error_for_status() {
+                let data: Value = resp.json().await?;
+                extract_symbols(&data, &mut symbols);
+            }
+        }
+    }
+    symbols.sort();
+    symbols.dedup();
+    Ok(symbols)
+}
+
+static REGISTER: Once = Once::new();
+
+pub fn register() {
+    REGISTER.call_once(|| {
+        for exch in XT_EXCHANGES {
+            let cfg_ref: &'static XtConfig = exch;
+            registry::register_adapter(
+                cfg_ref.id,
+                Arc::new(
+                    move |
+                          global_cfg: &'static core::config::Config,
+                          exchange_cfg: &core::config::ExchangeConfig,
+                          client: Client,
+                          task_set: TaskSet,
+                          channels: ChannelRegistry,
+                          _tls_config: Arc<rustls::ClientConfig>| -> BoxFuture<'static, Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>>> {
+                        let cfg = cfg_ref;
+                        let initial_symbols = exchange_cfg.symbols.clone();
+                        Box::pin(async move {
+                            let mut symbols = initial_symbols;
+                            if symbols.is_empty() {
+                                symbols = fetch_symbols().await?;
+                            }
+
+                            let mut receivers = Vec::new();
+                            for symbol in &symbols {
+                                let key = format!("{}:{}", cfg.name, symbol);
+                                let (_, rx) = channels.get_or_create(&key);
+                                if let Some(rx) = rx {
+                                    receivers.push(rx);
+                                }
+                            }
+
+                            let adapter = XtAdapter::new(cfg, client.clone(), global_cfg.chunk_size, symbols);
+
+                            {
+                                let mut set = task_set.lock().await;
+                                set.spawn(async move {
+                                    let mut adapter = adapter;
+                                    if let Err(e) = adapter.run().await {
+                                        error!("Failed to run adapter: {}", e);
+                                    }
+                                });
+                            }
+
+                            Ok(receivers)
+                        })
+                    },
+                ),
+            );
+        }
+    });
+}
+
+/// Adapter implementing the `ExchangeAdapter` trait for XT.
+pub struct XtAdapter {
+    cfg: &'static XtConfig,
+    _client: Client,
+    chunk_size: usize,
+    symbols: Vec<String>,
+    _books: Arc<DashMap<String, OrderBook>>,
+    http_bucket: Arc<TokenBucket>,
+    ws_bucket: Arc<TokenBucket>,
+    tasks: Vec<JoinHandle<Result<()>>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl XtAdapter {
+    pub fn new(
+        cfg: &'static XtConfig,
+        client: Client,
+        chunk_size: usize,
+        symbols: Vec<String>,
+    ) -> Self {
+        let global_cfg = core::config::get();
+        Self {
+            cfg,
+            _client: client,
+            chunk_size,
+            symbols,
+            _books: Arc::new(DashMap::new()),
+            http_bucket: Arc::new(TokenBucket::new(
+                global_cfg.http_burst,
+                global_cfg.http_refill_per_sec,
+                std::time::Duration::from_secs(1),
+            )),
+            ws_bucket: Arc::new(TokenBucket::new(
+                global_cfg.ws_burst,
+                global_cfg.ws_refill_per_sec,
+                std::time::Duration::from_secs(1),
+            )),
+            tasks: Vec::new(),
+            shutdown: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[async_trait]
+impl ExchangeAdapter for XtAdapter {
+    async fn subscribe(&mut self) -> Result<()> {
+        let symbol_refs: Vec<&str> = self.symbols.iter().map(|s| s.as_str()).collect();
+        let cfg = stream_config_for_exchange(self.cfg.name);
+        let chunks = chunk_streams_with_config(&symbol_refs, self.chunk_size, cfg);
+
+        for chunk in chunks {
+            let stream_path = chunk.join("/");
+            let ws_url = format!("{}{}", self.cfg.ws_base, stream_path);
+            let ws_bucket = self.ws_bucket.clone();
+            let shutdown = self.shutdown.clone();
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    ws_bucket.acquire(1).await;
+                    match connect_async(&ws_url).await {
+                        Ok((mut ws, _)) => {
+                            loop {
+                                tokio::select! {
+                                    msg = ws.next() => {
+                                        match msg {
+                                            Some(Ok(Message::Ping(p))) => {
+                                                ws.send(Message::Pong(p)).await.map_err(|e| {
+                                                    tracing::error!("xt ws pong error: {}", e);
+                                                    e
+                                                })?;
+                                            },
+                                            Some(Ok(Message::Close(_))) | None => { break; },
+                                            Some(Ok(_)) => {},
+                                            Some(Err(e)) => { tracing::warn!("xt ws error: {}", e); break; },
+                                        }
+                                    }
+                                    _ = async {
+                                        while !shutdown.load(Ordering::Relaxed) {
+                                            sleep(Duration::from_secs(1)).await;
+                                        }
+                                    } => {
+                                        let _ = ws.close(None).await;
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("xt connect error: {}", e);
+                        }
+                    }
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    sleep(Duration::from_secs(5)).await;
+                }
+                Ok::<(), anyhow::Error>(())
+            });
+            self.tasks.push(handle);
+        }
+        Ok(())
+    }
+
+    async fn run(&mut self) -> Result<()> {
+        self.subscribe().await?;
+
+        let _ = signal::ctrl_c().await;
+        self.shutdown.store(true, Ordering::SeqCst);
+
+        for handle in self.tasks.drain(..) {
+            let _ = handle.await;
+        }
+        Ok(())
+    }
+
+    async fn heartbeat(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn auth(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn backfill(&mut self) -> Result<()> {
+        self.http_bucket.acquire(1).await;
+        Ok(())
+    }
+}
+

--- a/agents/src/lib.rs
+++ b/agents/src/lib.rs
@@ -16,6 +16,7 @@ pub use adapter::binance::{
     fetch_symbols as fetch_binance_symbols, BinanceAdapter, BINANCE_EXCHANGES,
 };
 pub use adapter::mexc::{fetch_symbols, MexcAdapter, MEXC_EXCHANGES};
+pub use adapter::xt::{fetch_symbols as fetch_xt_symbols, XtAdapter, XT_EXCHANGES};
 pub use adapter::ExchangeAdapter;
 
 /// Shared task set type for spawning and tracking asynchronous tasks.
@@ -105,6 +106,7 @@ pub async fn spawn_adapters(
 ) -> Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>> {
     adapter::binance::register();
     adapter::mexc::register();
+    adapter::xt::register();
 
     let mut receivers = Vec::new();
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -60,6 +60,11 @@ static GATEIO_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     from_slice(&mut data).expect("invalid gateio stream configuration")
 });
 
+static XT_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
+    let mut data = include_bytes!("../../streams_xt.json").to_vec();
+    from_slice(&mut data).expect("invalid xt stream configuration")
+});
+
 /// Returns the default stream configuration.
 pub fn default_stream_config() -> &'static StreamConfig {
     &STREAM_CONFIG
@@ -72,6 +77,7 @@ pub fn stream_config_for_exchange(name: &str) -> &'static StreamConfig {
         "Binance Futures" | "Binance Delivery" => &FUTURES_STREAM_CONFIG,
         "Binance Options" => &OPTIONS_STREAM_CONFIG,
         "Gate.io Spot" => &GATEIO_STREAM_CONFIG,
+        "XT Spot" | "XT Futures" => &XT_STREAM_CONFIG,
         _ => default_stream_config(),
     }
 }

--- a/streams_xt.json
+++ b/streams_xt.json
@@ -1,0 +1,4 @@
+{
+  "global": [],
+  "per_symbol": ["depth", "trade", "ticker"]
+}


### PR DESCRIPTION
## Summary
- introduce XT adapter supporting spot and futures streams
- aggregate symbols from both spot and futures REST endpoints
- wire XT configs and stream settings for depth/trade/ticker

## Testing
- `cargo test` *(fails: no variant or associated item named `Book` found for enum `MdEvent`)*

------
https://chatgpt.com/codex/tasks/task_e_689f8ece91c48323889db91b4bfd90b2