### PR TITLE
Add exchange field to trades and normalize timestamps

### DIFF
--- a/canonical/src/lib.rs
+++ b/canonical/src/lib.rs
@@ -36,6 +36,7 @@ pub enum MdEvent {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Trade {
+    pub exchange: String,
     pub symbol: String,
     pub price: f64,
     pub quantity: f64,
@@ -178,13 +179,14 @@ impl<'a> From<TradeEvent<'a>> for Trade {
         let price = ev.price_decimal().to_f64().unwrap_or_default();
         let quantity = ev.quantity_decimal().to_f64().unwrap_or_default();
         Self {
+            exchange: "binance".to_string(),
             symbol: ev.symbol,
             price,
             quantity,
             trade_id: Some(ev.trade_id),
             buyer_order_id: Some(ev.buyer_order_id),
             seller_order_id: Some(ev.seller_order_id),
-            timestamp: ev.trade_time.saturating_mul(1_000_000),
+            timestamp: ev.trade_time,
             side: Some(side),
         }
     }
@@ -233,7 +235,7 @@ impl<'a> From<DepthUpdateEvent<'a>> for DepthL2Update {
         Self {
             exchange: "binance".to_string(),
             symbol: ev.symbol,
-            ts: ev.event_time.saturating_mul(1_000_000),
+            ts: ev.event_time,
             bids,
             asks,
             first_update_id: Some(ev.first_update_id),
@@ -510,13 +512,14 @@ impl<'a> TryFrom<MexcStreamMessage<'a>> for MdEvent {
                     _ => None,
                 };
                 Ok(MdEvent::Trade(Trade {
+                    exchange: "mexc".to_string(),
                     symbol: msg.symbol,
                     price,
                     quantity,
                     trade_id: None,
                     buyer_order_id: None,
                     seller_order_id: None,
-                    timestamp: deal.trade_time.saturating_mul(1_000_000),
+                    timestamp: deal.trade_time,
                     side,
                 }))
             }

--- a/canonical/tests/convert.rs
+++ b/canonical/tests/convert.rs
@@ -31,8 +31,12 @@ fn trade_event_to_canonical() {
     let md: MdEvent = MdEvent::from(trade_event);
     match md {
         MdEvent::Trade(ref t) => {
+            assert_eq!(t.exchange, "binance");
             assert_eq!(t.symbol, "BTCUSD");
             assert_eq!(t.price, 100.0);
+            let s = serde_json::to_string(t).unwrap();
+            let de: Trade = serde_json::from_str(&s).unwrap();
+            assert_eq!(*t, de);
         }
         _ => panic!("expected trade"),
     }
@@ -51,6 +55,7 @@ fn trade_event_to_canonical() {
     let event = Event::Trade(trade_event2);
     let trade = Trade::try_from(event).unwrap();
     assert_eq!(trade.quantity, 1.5);
+    assert_eq!(trade.exchange, "binance");
 }
 
 #[test]
@@ -72,9 +77,13 @@ fn mexc_trade_event_to_canonical() {
     let md = MdEvent::try_from(msg).unwrap();
     match md {
         MdEvent::Trade(t) => {
+            assert_eq!(t.exchange, "mexc");
             assert_eq!(t.symbol, "BTCUSDT");
             assert_eq!(t.price, 93220.0);
             assert_eq!(t.side, Some(Side::Sell));
+            let s = serde_json::to_string(&t).unwrap();
+            let de: Trade = serde_json::from_str(&s).unwrap();
+            assert_eq!(t, de);
         }
         _ => panic!("expected trade"),
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -69,6 +69,8 @@ static GATEIO_FUTURES_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
 static LATOKEN_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     let mut data = include_bytes!("../../streams_latoken.json").to_vec();
     from_slice(&mut data).expect("invalid latoken stream configuration")
+});
+
 static BITGET_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     let mut data = include_bytes!("../../streams_bitget.json").to_vec();
     from_slice(&mut data).expect("invalid bitget stream configuration")
@@ -127,7 +129,6 @@ pub fn stream_config_for_exchange(name: &str) -> &'static StreamConfig {
         "Binance Options" => &OPTIONS_STREAM_CONFIG,
         "Gate.io Spot" => &GATEIO_SPOT_STREAM_CONFIG,
         "Gate.io Futures" => &GATEIO_FUTURES_STREAM_CONFIG,
-        "Gate.io Spot" => &GATEIO_STREAM_CONFIG,
         "BingX Spot" | "BingX Swap" => &BINGX_STREAM_CONFIG,
         "KuCoin Spot" => &KUCOIN_SPOT_STREAM_CONFIG,
         "KuCoin Futures" => &KUCOIN_FUTURES_STREAM_CONFIG,


### PR DESCRIPTION
## Summary
- include exchange name in canonical Trade events and convert timestamps to milliseconds
- propagate exchange field in conversions and update tests
- fix stream configuration compilation errors in core crate

## Testing
- `cargo test -p canonical`


------
https://chatgpt.com/codex/tasks/task_e_689f998cd7448323ba6b7d8b36822aef