### PR TITLE
Format workspace and fix duplicate module

### DIFF
--- a/agents/src/adapter/bitmart.rs
+++ b/agents/src/adapter/bitmart.rs
@@ -37,11 +37,7 @@ pub const BITMART_EXCHANGES: &[BitmartConfig] = &[
 
 /// Retrieve all spot trading symbols from BitMart.
 pub async fn fetch_spot_symbols(url: &str) -> Result<Vec<String>> {
-    let resp = Client::new()
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?;
+    let resp = Client::new().get(url).send().await?.error_for_status()?;
     let data: Value = resp.json().await?;
     let arr = data
         .get("data")
@@ -73,11 +69,7 @@ pub async fn fetch_spot_symbols(url: &str) -> Result<Vec<String>> {
 
 /// Retrieve all contract trading symbols from BitMart.
 pub async fn fetch_contract_symbols(url: &str) -> Result<Vec<String>> {
-    let resp = Client::new()
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()?;
+    let resp = Client::new().get(url).send().await?.error_for_status()?;
     let data: Value = resp.json().await?;
     let arr = data
         .get("data")
@@ -191,8 +183,8 @@ impl ExchangeAdapter for BitmartAdapter {
 
     async fn run(&mut self) -> Result<()> {
         self.auth().await?;
-       self.backfill().await?;
-       self.subscribe().await?;
+        self.backfill().await?;
+        self.subscribe().await?;
         self.heartbeat().await?;
         Ok(())
     }

--- a/agents/src/adapter/gateio.rs
+++ b/agents/src/adapter/gateio.rs
@@ -56,9 +56,7 @@ pub async fn fetch_symbols(cfg: &GateioConfig) -> Result<Vec<String>> {
                     .await?
                     .error_for_status()?;
                 let data: Value = resp.json().await?;
-                let arr = data
-                    .as_array()
-                    .ok_or_else(|| anyhow!("expected array"))?;
+                let arr = data.as_array().ok_or_else(|| anyhow!("expected array"))?;
                 if arr.is_empty() {
                     break;
                 }
@@ -95,9 +93,7 @@ pub async fn fetch_symbols(cfg: &GateioConfig) -> Result<Vec<String>> {
                 .await?
                 .error_for_status()?;
             let data: Value = resp.json().await?;
-            let arr = data
-                .as_array()
-                .ok_or_else(|| anyhow!("expected array"))?;
+            let arr = data.as_array().ok_or_else(|| anyhow!("expected array"))?;
             if arr.is_empty() {
                 break;
             }
@@ -134,8 +130,7 @@ pub fn register() {
             registry::register_adapter(
                 cfg_ref.id,
                 Arc::new(
-                    move |
-                          global_cfg: &'static core::config::Config,
+                    move |global_cfg: &'static core::config::Config,
                           exchange_cfg: &core::config::ExchangeConfig,
                           client: Client,
                           task_set: TaskSet,
@@ -238,4 +233,3 @@ impl ExchangeAdapter for GateioAdapter {
         Ok(())
     }
 }
-

--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -23,14 +23,13 @@ pub trait ExchangeAdapter {
 }
 
 pub mod binance;
-pub mod gateio;
-pub mod lbank;
 pub mod bingx;
-pub mod kucoin;
+pub mod bitget;
+pub mod bitmart;
 pub mod coinex;
 pub mod gateio;
-pub mod xt;
-pub mod bitmart;
-pub mod bitget;
+pub mod kucoin;
 pub mod latoken;
+pub mod lbank;
 pub mod mexc;
+pub mod xt;

--- a/agents/src/lib.rs
+++ b/agents/src/lib.rs
@@ -15,13 +15,15 @@ pub mod registry;
 pub use adapter::binance::{
     fetch_symbols as fetch_binance_symbols, BinanceAdapter, BINANCE_EXCHANGES,
 };
-pub use adapter::kucoin::{fetch_symbols as fetch_kucoin_symbols, KucoinAdapter, KUCOIN_EXCHANGES};
-pub use adapter::mexc::{fetch_symbols, MexcAdapter, MEXC_EXCHANGES};
-pub use adapter::xt::{fetch_symbols as fetch_xt_symbols, XtAdapter, XT_EXCHANGES};
 pub use adapter::bitmart::{
     fetch_symbols as fetch_bitmart_symbols, BitmartAdapter, BITMART_EXCHANGES,
 };
-pub use adapter::latoken::{fetch_symbols as fetch_latoken_symbols, LatokenAdapter, LATOKEN_EXCHANGES};
+pub use adapter::kucoin::{fetch_symbols as fetch_kucoin_symbols, KucoinAdapter, KUCOIN_EXCHANGES};
+pub use adapter::latoken::{
+    fetch_symbols as fetch_latoken_symbols, LatokenAdapter, LATOKEN_EXCHANGES,
+};
+pub use adapter::mexc::{fetch_symbols, MexcAdapter, MEXC_EXCHANGES};
+pub use adapter::xt::{fetch_symbols as fetch_xt_symbols, XtAdapter, XT_EXCHANGES};
 pub use adapter::ExchangeAdapter;
 
 /// Shared task set type for spawning and tracking asynchronous tasks.
@@ -119,7 +121,7 @@ pub async fn spawn_adapters(
     adapter::coinex::register();
     adapter::latoken::register();
     adapter::bitget::register();
-  
+
     let mut receivers = Vec::new();
 
     for exch in &cfg.exchanges {

--- a/canonical/src/lib.rs
+++ b/canonical/src/lib.rs
@@ -3,20 +3,15 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 pub use arb_core::events;
+use arb_core::events::Channel;
 pub use arb_core::events::{
     BookTickerEvent, Event, KlineEvent, MexcEvent, MexcStreamMessage, MiniTickerEvent,
     StreamMessage, TickerEvent,
 };
 use arb_core::DepthSnapshot as CoreDepthSnapshot;
-use arb_core::events::Channel;
 use events::{
-    DepthUpdateEvent,
-    TradeEvent,
-    MarkPriceEvent,
-    IndexPriceEvent,
-    FundingRateEvent,
-    OpenInterestEvent,
-    ForceOrderEvent,
+    DepthUpdateEvent, ForceOrderEvent, FundingRateEvent, IndexPriceEvent, MarkPriceEvent,
+    OpenInterestEvent, TradeEvent,
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -176,7 +171,11 @@ pub struct Liquidation {
 
 impl<'a> From<TradeEvent<'a>> for Trade {
     fn from(ev: TradeEvent<'a>) -> Self {
-        let side = if ev.buyer_is_maker { Side::Sell } else { Side::Buy };
+        let side = if ev.buyer_is_maker {
+            Side::Sell
+        } else {
+            Side::Buy
+        };
         let price = ev.price_decimal().to_f64().unwrap_or_default();
         let quantity = ev.quantity_decimal().to_f64().unwrap_or_default();
         Self {
@@ -462,7 +461,11 @@ impl<'a> From<OpenInterestEvent<'a>> for MdEvent {
 impl<'a> From<ForceOrderEvent<'a>> for Liquidation {
     fn from(ev: ForceOrderEvent<'a>) -> Self {
         let price = ev.order.price_decimal().to_f64().unwrap_or_default();
-        let quantity = ev.order.original_quantity_decimal().to_f64().unwrap_or_default();
+        let quantity = ev
+            .order
+            .original_quantity_decimal()
+            .to_f64()
+            .unwrap_or_default();
         Self {
             exchange: "binance".to_string(),
             symbol: ev.order.symbol,
@@ -667,4 +670,3 @@ impl Liquidation {
         Channel::Liquidation
     }
 }
-

--- a/canonical/tests/convert.rs
+++ b/canonical/tests/convert.rs
@@ -1,16 +1,15 @@
+use arb_core::DepthSnapshot as CoreDepthSnapshot;
 use canonical::{
     events::{
-        Event, FundingRateEvent, ForceOrder, ForceOrderEvent, IndexPriceEvent,
-        Kline as EventKline, KlineEvent, MarkPriceEvent, MexcStreamMessage,
-        MiniTickerEvent, OpenInterestEvent, TickerEvent, TradeEvent,
+        Event, ForceOrder, ForceOrderEvent, FundingRateEvent, IndexPriceEvent, Kline as EventKline,
+        KlineEvent, MarkPriceEvent, MexcStreamMessage, MiniTickerEvent, OpenInterestEvent,
+        TickerEvent, TradeEvent,
     },
     AvgPrice, BookTicker, DepthL2Update, DepthSnapshot as CanonDepthSnapshot,
-    FundingRate as CanonFundingRate, IndexPrice as CanonIndexPrice,
-    Kline as CanonKline, Liquidation as CanonLiquidation, MarkPrice as CanonMarkPrice,
-    MdEvent, MiniTicker as CanonMiniTicker, OpenInterest as CanonOpenInterest,
-    Side, Trade,
+    FundingRate as CanonFundingRate, IndexPrice as CanonIndexPrice, Kline as CanonKline,
+    Liquidation as CanonLiquidation, MarkPrice as CanonMarkPrice, MdEvent,
+    MiniTicker as CanonMiniTicker, OpenInterest as CanonOpenInterest, Side, Trade,
 };
-use arb_core::DepthSnapshot as CoreDepthSnapshot;
 use serde_json::json;
 use std::borrow::Cow;
 
@@ -73,7 +72,8 @@ fn mexc_trade_event_to_canonical() {
         },
         "symbol": "BTCUSDT",
         "sendtime": 1736409765052u64
-    })).unwrap();
+    }))
+    .unwrap();
     let md = MdEvent::try_from(msg).unwrap();
     match md {
         MdEvent::Trade(t) => {
@@ -102,7 +102,8 @@ fn mexc_depth_event_to_canonical() {
         },
         "symbol": "BTCUSDT",
         "sendtime": 1736411507002u64
-    })).unwrap();
+    }))
+    .unwrap();
     let md = MdEvent::try_from(msg).unwrap();
     match md {
         MdEvent::DepthL2Update(b) => {
@@ -129,7 +130,8 @@ fn mexc_book_ticker_event_to_canonical() {
         },
         "symbol": "BTCUSDT",
         "sendtime": 1736412092433u64
-    })).unwrap();
+    }))
+    .unwrap();
     let md = MdEvent::try_from(msg).unwrap();
     match md {
         MdEvent::BookTicker(t) => {
@@ -374,4 +376,3 @@ fn force_order_event_to_canonical() {
         _ => panic!("expected liquidation"),
     }
 }
-

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -61,7 +61,9 @@ fn is_missing_required_symbols(enabled: bool, list_is_empty: bool, all_flag: boo
 }
 
 fn rate_limits_present(http_burst: u32, http_refill: u32, ws_burst: u32, ws_refill: u32) -> bool {
-    [http_burst, http_refill, ws_burst, ws_refill].iter().all(|&v| v > 0)
+    [http_burst, http_refill, ws_burst, ws_refill]
+        .iter()
+        .all(|&v| v > 0)
 }
 
 /* -------------------- helpers to avoid nested conditionals -------------------- */
@@ -69,7 +71,10 @@ fn rate_limits_present(http_burst: u32, http_refill: u32, ws_burst: u32, ws_refi
 fn creds_from_env() -> Option<Credentials> {
     let api_key = env::var("API_KEY").ok()?;
     let api_secret = env::var("API_SECRET").ok()?;
-    let c = Credentials { api_key, api_secret };
+    let c = Credentials {
+        api_key,
+        api_secret,
+    };
     has_valid_credentials(&c).then_some(c)
 }
 
@@ -217,11 +222,8 @@ impl Config {
             .unwrap_or_default()
             .eq_ignore_ascii_case("ALL");
 
-        let missing_spot = is_missing_required_symbols(
-            self.enable_spot,
-            self.spot_symbols.is_empty(),
-            spot_all,
-        );
+        let missing_spot =
+            is_missing_required_symbols(self.enable_spot, self.spot_symbols.is_empty(), spot_all);
         let missing_futures = is_missing_required_symbols(
             self.enable_futures,
             self.futures_symbols.is_empty(),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -67,7 +67,6 @@ static GATEIO_FUTURES_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     from_slice(&mut data).expect("invalid gateio futures stream configuration")
 });
 
-
 static LATOKEN_STREAM_CONFIG: Lazy<StreamConfig> = Lazy::new(|| {
     let mut data = include_bytes!("../../streams_latoken.json").to_vec();
     from_slice(&mut data).expect("invalid latoken stream configuration")

--- a/core/tests/backoff.rs
+++ b/core/tests/backoff.rs
@@ -9,9 +9,21 @@ fn backoff_resets_after_stable_run() {
     let min_stable = Duration::from_secs(5);
     let mut backoff = Duration::from_secs(1);
 
-    backoff = next_backoff(backoff, Duration::from_secs(0), false, max_backoff, min_stable);
+    backoff = next_backoff(
+        backoff,
+        Duration::from_secs(0),
+        false,
+        max_backoff,
+        min_stable,
+    );
     assert_eq!(backoff, Duration::from_secs(2));
 
-    backoff = next_backoff(backoff, Duration::from_secs(10), true, max_backoff, min_stable);
+    backoff = next_backoff(
+        backoff,
+        Duration::from_secs(10),
+        true,
+        max_backoff,
+        min_stable,
+    );
     assert_eq!(backoff, Duration::from_secs(1));
 }

--- a/core/tests/event_channel_mapping.rs
+++ b/core/tests/event_channel_mapping.rs
@@ -1,11 +1,15 @@
 use arb_core::events::Channel;
 use canonical::{
-    AvgPrice, BookKind, BookTicker, DepthL2Update, DepthSnapshot, FundingRate, Kline,
-    Level, Liquidation, MarkPrice, MdEvent, MiniTicker, OpenInterest, Trade, IndexPrice,
+    AvgPrice, BookKind, BookTicker, DepthL2Update, DepthSnapshot, FundingRate, IndexPrice, Kline,
+    Level, Liquidation, MarkPrice, MdEvent, MiniTicker, OpenInterest, Trade,
 };
 
 fn sample_level(kind: BookKind) -> Level {
-    Level { price: 0.0, quantity: 0.0, kind }
+    Level {
+        price: 0.0,
+        quantity: 0.0,
+        kind,
+    }
 }
 
 #[test]
@@ -81,22 +85,53 @@ fn channel_enum_matches_events() {
     };
     assert_eq!(depth_snapshot.channel(), Channel::Depth);
 
-    let avg_price = AvgPrice { exchange: "ex".into(), symbol: "sym".into(), ts: 0, price: 0.0 };
+    let avg_price = AvgPrice {
+        exchange: "ex".into(),
+        symbol: "sym".into(),
+        ts: 0,
+        price: 0.0,
+    };
     assert_eq!(avg_price.channel(), Channel::AvgPrice);
 
-    let mark_price = MarkPrice { exchange: "ex".into(), symbol: "sym".into(), ts: 0, price: 0.0 };
+    let mark_price = MarkPrice {
+        exchange: "ex".into(),
+        symbol: "sym".into(),
+        ts: 0,
+        price: 0.0,
+    };
     assert_eq!(mark_price.channel(), Channel::MarkPrice);
 
-    let index_price = IndexPrice { exchange: "ex".into(), symbol: "sym".into(), ts: 0, price: 0.0 };
+    let index_price = IndexPrice {
+        exchange: "ex".into(),
+        symbol: "sym".into(),
+        ts: 0,
+        price: 0.0,
+    };
     assert_eq!(index_price.channel(), Channel::IndexPrice);
 
-    let funding = FundingRate { exchange: "ex".into(), symbol: "sym".into(), ts: 0, rate: 0.0 };
+    let funding = FundingRate {
+        exchange: "ex".into(),
+        symbol: "sym".into(),
+        ts: 0,
+        rate: 0.0,
+    };
     assert_eq!(funding.channel(), Channel::FundingRate);
 
-    let oi = OpenInterest { exchange: "ex".into(), symbol: "sym".into(), ts: 0, open_interest: 0.0 };
+    let oi = OpenInterest {
+        exchange: "ex".into(),
+        symbol: "sym".into(),
+        ts: 0,
+        open_interest: 0.0,
+    };
     assert_eq!(oi.channel(), Channel::OpenInterest);
 
-    let liq = Liquidation { exchange: "ex".into(), symbol: "sym".into(), ts: 0, price: 0.0, quantity: 0.0 };
+    let liq = Liquidation {
+        exchange: "ex".into(),
+        symbol: "sym".into(),
+        ts: 0,
+        price: 0.0,
+        quantity: 0.0,
+    };
     assert_eq!(liq.channel(), Channel::Liquidation);
 
     let md: MdEvent = MdEvent::Trade(trade);

--- a/core/tests/exchange_configs.rs
+++ b/core/tests/exchange_configs.rs
@@ -8,11 +8,23 @@ fn spot_config_excludes_futures_streams() {
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("markPrice")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("indexPrice")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("forceOrder")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("continuousKline")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("continuousKline")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("openInterest")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("topLongShortPositionRatio")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("topLongShortAccountRatio")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("takerBuySellVolume")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("topLongShortPositionRatio")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("topLongShortAccountRatio")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("takerBuySellVolume")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("depth5@100ms")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("depth10@100ms")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("depth20@100ms")));
@@ -25,9 +37,18 @@ fn futures_config_includes_futures_streams() {
     assert!(cfg.per_symbol.iter().any(|s| s.contains("markPrice")));
     assert!(cfg.per_symbol.iter().any(|s| s.contains("forceOrder")));
     assert!(cfg.per_symbol.iter().any(|s| s.contains("openInterest")));
-    assert!(cfg.per_symbol.iter().any(|s| s.contains("topLongShortPositionRatio")));
-    assert!(cfg.per_symbol.iter().any(|s| s.contains("topLongShortAccountRatio")));
-    assert!(cfg.per_symbol.iter().any(|s| s.contains("takerBuySellVolume")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .any(|s| s.contains("topLongShortPositionRatio")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .any(|s| s.contains("topLongShortAccountRatio")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .any(|s| s.contains("takerBuySellVolume")));
     assert!(cfg.per_symbol.iter().any(|s| s.contains("depth5@100ms")));
     assert!(cfg.per_symbol.iter().any(|s| s.contains("depth10@100ms")));
     assert!(cfg.per_symbol.iter().any(|s| s.contains("depth20@100ms")));
@@ -42,9 +63,18 @@ fn options_config_includes_options_streams() {
     assert!(cfg.global.iter().all(|s| !s.contains("markPrice")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("markPrice")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("forceOrder")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("topLongShortPositionRatio")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("topLongShortAccountRatio")));
-    assert!(cfg.per_symbol.iter().all(|s| !s.contains("takerBuySellVolume")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("topLongShortPositionRatio")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("topLongShortAccountRatio")));
+    assert!(cfg
+        .per_symbol
+        .iter()
+        .all(|s| !s.contains("takerBuySellVolume")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("depth5@100ms")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("depth10@100ms")));
     assert!(cfg.per_symbol.iter().all(|s| !s.contains("depth20@100ms")));

--- a/core/tests/order_book.rs
+++ b/core/tests/order_book.rs
@@ -1,6 +1,6 @@
 use arb_core as core;
-use core::{apply_depth_update, fast_forward, ApplyResult, DepthSnapshot, OrderBook};
 use core::events::DepthUpdateEvent;
+use core::{apply_depth_update, fast_forward, ApplyResult, DepthSnapshot, OrderBook};
 
 #[test]
 fn merges_snapshot_and_diff() {

--- a/core/tests/unknown_event_warning.rs
+++ b/core/tests/unknown_event_warning.rs
@@ -1,8 +1,5 @@
 use arb_core as core;
-use core::{
-    events::StreamMessage,
-    handle_stream_event,
-};
+use core::{events::StreamMessage, handle_stream_event};
 use tracing_test::traced_test;
 
 #[traced_test]

--- a/core/tests/util.rs
+++ b/core/tests/util.rs
@@ -1,8 +1,8 @@
 #![allow(unused_imports, dead_code, unused_macros)]
 
-pub use typenum::*;
-pub use core::ops::*;
 pub use core::cmp::Ordering;
+pub use core::ops::*;
+pub use typenum::*;
 
 pub type U0 = UTerm;
 pub type U1 = UInt<U0, B1>;
@@ -16,7 +16,10 @@ macro_rules! assert_binary_op {
         #[test]
         fn $name() {
             type Result = <<$a as $trait<$b>>::Output as Same<$expected>>::Output;
-            assert_eq!(<Result as Unsigned>::to_u64(), <$expected as Unsigned>::to_u64());
+            assert_eq!(
+                <Result as Unsigned>::to_u64(),
+                <$expected as Unsigned>::to_u64()
+            );
         }
     };
 }

--- a/ingestor/benches/event_alloc.rs
+++ b/ingestor/benches/event_alloc.rs
@@ -1,9 +1,9 @@
 use arb_core as core;
-use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::events::StreamMessage;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use serde::Deserialize;
-use core::events::StreamMessage;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 struct CountingAlloc;
 

--- a/ingestor/benches/json_parse.rs
+++ b/ingestor/benches/json_parse.rs
@@ -1,8 +1,8 @@
 use arb_core as core;
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use core::events::StreamMessage;
-use simd_json::serde::from_slice as simd_from_slice;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use serde_json;
+use simd_json::serde::from_slice as simd_from_slice;
 
 const RAW: &str = r#"{"stream":"btcusdt@trade","data":{"e":"trade","E":123,"s":"BTCUSDT","t":1,"p":"0.001","q":"100","b":1,"a":2,"T":123,"m":true,"M":true}}"#;
 

--- a/ingestor/tests/mock_agent.rs
+++ b/ingestor/tests/mock_agent.rs
@@ -11,7 +11,9 @@ struct MockAdapter {
 
 #[async_trait::async_trait]
 impl ExchangeAdapter for MockAdapter {
-    async fn subscribe(&mut self) -> anyhow::Result<()> { Ok(()) }
+    async fn subscribe(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
     async fn run(&mut self) -> anyhow::Result<()> {
         let trade = TradeEvent {
             event_time: 1,
@@ -25,13 +27,22 @@ impl ExchangeAdapter for MockAdapter {
             buyer_is_maker: false,
             best_match: true,
         };
-        let msg = StreamMessage { stream: "btcusd@trade".into(), data: Event::Trade(trade) };
+        let msg = StreamMessage {
+            stream: "btcusd@trade".into(),
+            data: Event::Trade(trade),
+        };
         self.tx.send(msg).await.unwrap();
         Ok(())
     }
-    async fn heartbeat(&mut self) -> anyhow::Result<()> { Ok(()) }
-    async fn auth(&mut self) -> anyhow::Result<()> { Ok(()) }
-    async fn backfill(&mut self) -> anyhow::Result<()> { Ok(()) }
+    async fn heartbeat(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn auth(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn backfill(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- remove duplicate `gateio` module declaration
- run `cargo fmt` across workspace

## Testing
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -W clippy::all -W clippy::pedantic`


------
https://chatgpt.com/codex/tasks/task_e_689fcc88e98c8323be26b2fc5a0d69f3