### PR TITLE
Add LBank websocket adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -2813,6 +2814,7 @@ version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/agents/Cargo.toml
+++ b/agents/Cargo.toml
@@ -21,6 +21,7 @@ rustls = "0.21"
 serde_json = "1"
 dashmap = "5"
 once_cell = "1"
+uuid = { version = "1", features = ["v4"] }
 
 [features]
 default = []

--- a/agents/src/adapter/lbank.rs
+++ b/agents/src/adapter/lbank.rs
@@ -1,12 +1,16 @@
 use anyhow::{anyhow, Result};
 use arb_core as core;
 use async_trait::async_trait;
-use futures::future::BoxFuture;
+use futures::{future::BoxFuture, SinkExt, StreamExt};
 use reqwest::Client;
-use serde_json::Value;
+use serde_json::{json, Value};
+use std::borrow::Cow;
 use std::sync::{Arc, Once};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::{interval, Duration};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use tracing::error;
+use uuid::Uuid;
 
 use super::ExchangeAdapter;
 use crate::{registry, ChannelRegistry, TaskSet};
@@ -22,7 +26,7 @@ pub struct LbankConfig {
 pub const LBANK_EXCHANGES: &[LbankConfig] = &[LbankConfig {
     id: "lbank_spot",
     name: "LBank",
-    ws_base: "wss://api.lbkex.com/ws/v2/",
+    ws_base: "wss://api.lbkex.com/ws",
 }];
 
 const SPOT_URL: &str = "https://api.lbkex.com/v2/currencyPairs.do";
@@ -103,6 +107,7 @@ pub fn register() {
                                 client.clone(),
                                 global_cfg.chunk_size,
                                 symbols,
+                                channels.clone(),
                             );
 
                             {
@@ -130,6 +135,7 @@ pub struct LbankAdapter {
     _client: Client,
     _chunk_size: usize,
     _symbols: Vec<String>,
+    channels: ChannelRegistry,
 }
 
 impl LbankAdapter {
@@ -138,23 +144,262 @@ impl LbankAdapter {
         client: Client,
         chunk_size: usize,
         symbols: Vec<String>,
+        channels: ChannelRegistry,
     ) -> Self {
         Self {
             _cfg: cfg,
             _client: client,
             _chunk_size: chunk_size,
             _symbols: symbols,
+            channels,
         }
     }
+
+    async fn run_symbol(
+        url: String,
+        symbol: String,
+        tx: mpsc::Sender<core::events::StreamMessage<'static>>,
+    ) -> Result<()> {
+        let (ws_stream, _) = connect_async(&url).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        // subscribe to topics
+        let sub_trade = json!({
+            "action": "subscribe",
+            "subscribe": "trade",
+            "pair": symbol
+        });
+        write.send(Message::Text(sub_trade.to_string())).await?;
+        let sub_depth = json!({
+            "action": "subscribe",
+            "subscribe": "depth",
+            "depth": "100",
+            "pair": symbol
+        });
+        write.send(Message::Text(sub_depth.to_string())).await?;
+        let sub_kbar = json!({
+            "action": "subscribe",
+            "subscribe": "kbar",
+            "kbar": "1min",
+            "pair": symbol
+        });
+        write.send(Message::Text(sub_kbar.to_string())).await?;
+
+        let write = Arc::new(Mutex::new(write));
+        let ping_writer = write.clone();
+        tokio::spawn(async move {
+            let mut intv = interval(Duration::from_secs(30));
+            loop {
+                intv.tick().await;
+                let ping = json!({"action":"ping","ping": Uuid::new_v4().to_string()});
+                if ping_writer
+                    .lock()
+                    .await
+                    .send(Message::Text(ping.to_string()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    if let Some(event) = parse_message(&text) {
+                        if tx.send(event).await.is_err() {
+                            break;
+                        }
+                    } else if let Ok(v) = serde_json::from_str::<Value>(&text) {
+                        if v.get("action").and_then(|a| a.as_str()) == Some("ping") {
+                            if let Some(id) = v.get("ping").and_then(|p| p.as_str()) {
+                                let pong = json!({"action":"pong","pong":id});
+                                let _ = write
+                                    .lock()
+                                    .await
+                                    .send(Message::Text(pong.to_string()))
+                                    .await;
+                            }
+                        }
+                    }
+                }
+                Ok(Message::Ping(data)) => {
+                    let _ = write.lock().await.send(Message::Pong(data)).await;
+                }
+                Err(_) => break,
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Parse a raw JSON text into a canonical stream message if possible.
+fn parse_message(text: &str) -> Option<core::events::StreamMessage<'static>> {
+    if let Ok(val) = serde_json::from_str::<Value>(text) {
+        if let Some(t) = val.get("type").and_then(|v| v.as_str()) {
+            match t {
+                "trade" => return parse_trade_frame(&val).ok(),
+                "depth" => return parse_depth_frame(&val).ok(),
+                "kbar" => return parse_kbar_frame(&val).ok(),
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+fn parse_kbar_frame(val: &Value) -> Result<core::events::StreamMessage<'static>> {
+    let pair = val
+        .get("pair")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing pair"))?
+        .to_string();
+    let kbar = val
+        .get("kbar")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow!("missing kbar"))?;
+    let open = kbar.get("o").and_then(|v| v.as_f64()).unwrap_or_default();
+    let high = kbar.get("h").and_then(|v| v.as_f64()).unwrap_or_default();
+    let low = kbar.get("l").and_then(|v| v.as_f64()).unwrap_or_default();
+    let close = kbar.get("c").and_then(|v| v.as_f64()).unwrap_or_default();
+    let volume = kbar.get("v").and_then(|v| v.as_f64()).unwrap_or_default();
+    let event = core::events::KlineEvent {
+        event_time: 0,
+        symbol: pair.clone(),
+        kline: core::events::Kline {
+            start_time: 0,
+            close_time: 0,
+            interval: "1m".to_string(),
+            open: Cow::Owned(open.to_string()),
+            close: Cow::Owned(close.to_string()),
+            high: Cow::Owned(high.to_string()),
+            low: Cow::Owned(low.to_string()),
+            volume: Cow::Owned(volume.to_string()),
+            trades: kbar.get("n").and_then(|v| v.as_u64()).unwrap_or(0),
+            is_closed: true,
+            quote_volume: Cow::Owned("0".to_string()),
+            taker_buy_base_volume: Cow::Owned("0".to_string()),
+            taker_buy_quote_volume: Cow::Owned("0".to_string()),
+        },
+    };
+    Ok(core::events::StreamMessage {
+        stream: Box::leak(format!("{}@kbar", pair).into_boxed_str()).into(),
+        data: core::events::Event::Kline(event),
+    })
+}
+
+/// Parse trade frame into canonical event.
+pub fn parse_trade_frame(val: &Value) -> Result<core::events::StreamMessage<'static>> {
+    let pair = val
+        .get("pair")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing pair"))?
+        .to_string();
+    let trade = val
+        .get("trade")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow!("missing trade"))?;
+    let price = trade
+        .get("price")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_default();
+    let volume = trade
+        .get("volume")
+        .and_then(|v| v.as_f64())
+        .unwrap_or_default();
+    let direction = trade
+        .get("direction")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let ev = core::events::TradeEvent {
+        event_time: 0,
+        symbol: pair.clone(),
+        trade_id: 0,
+        price: Cow::Owned(price.to_string()),
+        quantity: Cow::Owned(volume.to_string()),
+        buyer_order_id: 0,
+        seller_order_id: 0,
+        trade_time: 0,
+        buyer_is_maker: direction.eq_ignore_ascii_case("sell"),
+        best_match: true,
+    };
+    Ok(core::events::StreamMessage {
+        stream: Box::leak(format!("{}@trade", pair).into_boxed_str()).into(),
+        data: core::events::Event::Trade(ev),
+    })
+}
+
+/// Parse depth frame into canonical event.
+pub fn parse_depth_frame(val: &Value) -> Result<core::events::StreamMessage<'static>> {
+    let pair = val
+        .get("pair")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing pair"))?
+        .to_string();
+    let depth = val
+        .get("depth")
+        .and_then(|v| v.as_object())
+        .ok_or_else(|| anyhow!("missing depth"))?;
+    let mut bids = Vec::new();
+    if let Some(arr) = depth.get("bids").and_then(|v| v.as_array()) {
+        for level in arr.iter().filter_map(|l| l.as_array()) {
+            if level.len() == 2 {
+                let price = level[0].as_f64().unwrap_or_default().to_string();
+                let qty = level[1].as_f64().unwrap_or_default().to_string();
+                bids.push([Cow::Owned(price), Cow::Owned(qty)]);
+            }
+        }
+    }
+    let mut asks = Vec::new();
+    if let Some(arr) = depth.get("asks").and_then(|v| v.as_array()) {
+        for level in arr.iter().filter_map(|l| l.as_array()) {
+            if level.len() == 2 {
+                let price = level[0].as_f64().unwrap_or_default().to_string();
+                let qty = level[1].as_f64().unwrap_or_default().to_string();
+                asks.push([Cow::Owned(price), Cow::Owned(qty)]);
+            }
+        }
+    }
+
+    let ev = core::events::DepthUpdateEvent {
+        event_time: 0,
+        symbol: pair.clone(),
+        first_update_id: 0,
+        final_update_id: 0,
+        previous_final_update_id: 0,
+        bids,
+        asks,
+    };
+
+    Ok(core::events::StreamMessage {
+        stream: Box::leak(format!("{}@depth", pair).into_boxed_str()).into(),
+        data: core::events::Event::DepthUpdate(ev),
+    })
 }
 
 #[async_trait]
 impl ExchangeAdapter for LbankAdapter {
     async fn subscribe(&mut self) -> Result<()> {
+        for symbol in &self._symbols {
+            if let Some(tx) = self.channels.get(&format!("{}:{}", self._cfg.name, symbol)) {
+                let url = self._cfg.ws_base.to_string();
+                let sym = symbol.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = LbankAdapter::run_symbol(url, sym, tx).await {
+                        error!("lbank stream error: {}", e);
+                    }
+                });
+            }
+        }
         Ok(())
     }
     async fn run(&mut self) -> Result<()> {
-        self.subscribe().await
+        self.subscribe().await?;
+        futures::future::pending::<()>().await;
+        Ok(())
     }
     async fn heartbeat(&mut self) -> Result<()> {
         Ok(())

--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -23,14 +23,13 @@ pub trait ExchangeAdapter {
 }
 
 pub mod binance;
-pub mod gateio;
-pub mod lbank;
 pub mod bingx;
-pub mod kucoin;
+pub mod bitget;
+pub mod bitmart;
 pub mod coinex;
 pub mod gateio;
-pub mod xt;
-pub mod bitmart;
-pub mod bitget;
+pub mod kucoin;
 pub mod latoken;
+pub mod lbank;
 pub mod mexc;
+pub mod xt;

--- a/agents/tests/lbank.rs
+++ b/agents/tests/lbank.rs
@@ -1,0 +1,62 @@
+use agents::adapter::lbank::{parse_depth_frame, parse_trade_frame};
+use arb_core::events::Event;
+use serde_json::Value;
+
+#[test]
+fn lbank_parse_trade_and_print() {
+    let raw = r#"{
+        "trade":{"volume":6.3607,"amount":77148.9303,"price":12129,"direction":"sell","TS":"2019-06-28T19:55:49.460"},
+        "type":"trade",
+        "pair":"btc_usdt",
+        "SERVER":"V2",
+        "TS":"2019-06-28T19:55:49.466"
+    }"#;
+    let v: Value = serde_json::from_str(raw).unwrap();
+    let msg = parse_trade_frame(&v).unwrap();
+    if let Event::Trade(ev) = &msg.data {
+        assert_eq!(ev.price, "12129");
+        assert_eq!(ev.quantity, "6.3607");
+        let out = serde_json::json!({
+            "stream": msg.stream,
+            "data": {
+                "e": "trade",
+                "s": ev.symbol,
+                "p": ev.price,
+                "q": ev.quantity
+            }
+        });
+        println!("{}", out);
+    } else {
+        panic!("expected trade event");
+    }
+}
+
+#[test]
+fn lbank_parse_depth_and_print() {
+    let raw = r#"{
+        "depth":{"asks":[[0.0252,0.5833],[0.025215,4.377]],"bids":[[0.025135,3.962],[0.025134,3.46]]},
+        "count":100,
+        "type":"depth",
+        "pair":"eth_btc",
+        "SERVER":"V2",
+        "TS":"2019-06-28T17:49:22.722"
+    }"#;
+    let v: Value = serde_json::from_str(raw).unwrap();
+    let msg = parse_depth_frame(&v).unwrap();
+    if let Event::DepthUpdate(ev) = &msg.data {
+        assert_eq!(ev.bids.len(), 2);
+        assert_eq!(ev.asks.len(), 2);
+        let out = serde_json::json!({
+            "stream": msg.stream,
+            "data": {
+                "e": "depthUpdate",
+                "s": ev.symbol,
+                "b": ev.bids,
+                "a": ev.asks
+            }
+        });
+        println!("{}", out);
+    } else {
+        panic!("expected depth event");
+    }
+}


### PR DESCRIPTION
## Summary
- add LBank websocket adapter with trade, depth and kbar subscriptions
- parse LBank trade and depth frames into canonical events
- test LBank trade and depth parsing with NDJSON output

## Testing
- `cargo test --package agents lbank -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_689fcd9684288323aa1131a7d73526ac