### PR TITLE
Add LATOKEN websocket adapter and parsing tests

### DIFF
--- a/agents/src/adapter/latoken.rs
+++ b/agents/src/adapter/latoken.rs
@@ -1,20 +1,26 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use arb_core as core;
 use async_trait::async_trait;
 use core::{chunk_streams_with_config, stream_config_for_exchange};
+use futures::{SinkExt, StreamExt};
 use reqwest::Client;
 use serde_json::Value;
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Once};
 use tokio::sync::mpsc;
-use std::sync::Once;
-use crate::{registry, ChannelRegistry, TaskSet};
-use super::ExchangeAdapter;
-use futures::future::BoxFuture;
-use dashmap::DashMap;
-use core::rate_limit::TokenBucket;
-use tokio::task::JoinHandle;
-use std::sync::atomic::AtomicBool;
+use tokio::{
+    signal,
+    task::JoinHandle,
+    time::{interval, sleep, Duration},
+};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use tracing::error;
+
+use super::ExchangeAdapter;
+use crate::{registry, ChannelRegistry, TaskSet};
+use core::rate_limit::TokenBucket;
+use dashmap::DashMap;
+use futures::future::BoxFuture;
 
 /// Configuration for a single LATOKEN exchange endpoint.
 pub struct LatokenConfig {
@@ -29,17 +35,25 @@ pub const LATOKEN_EXCHANGES: &[LatokenConfig] = &[LatokenConfig {
     id: "latoken_spot",
     name: "LATOKEN",
     info_url: "https://api.latoken.com/v2/ticker",
-    ws_base: "wss://api.latoken.com/ws",
+    ws_base: "wss://ws.latoken.com",
 }];
 
 /// Retrieve all trading symbols for LATOKEN using its ticker endpoint.
 pub async fn fetch_symbols(info_url: &str) -> Result<Vec<String>> {
-    let resp = Client::new().get(info_url).send().await?.error_for_status()?;
+    let resp = Client::new()
+        .get(info_url)
+        .send()
+        .await?
+        .error_for_status()?;
     let data: Value = resp.json().await?;
     let arr = data.as_array().unwrap_or(&Vec::new()).clone();
     let mut result: Vec<String> = arr
         .iter()
-        .filter_map(|s| s.get("symbol").and_then(|v| v.as_str()).map(|v| v.to_string()))
+        .filter_map(|s| {
+            s.get("symbol")
+                .and_then(|v| v.as_str())
+                .map(|v| v.to_string())
+        })
         .collect();
     result.sort();
     result.dedup();
@@ -61,7 +75,10 @@ pub fn register() {
                           task_set: TaskSet,
                           channels: ChannelRegistry,
                           _tls_config: Arc<rustls::ClientConfig>|
-                          -> BoxFuture<'static, Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>>> {
+                          -> BoxFuture<
+                        'static,
+                        Result<Vec<mpsc::Receiver<core::events::StreamMessage<'static>>>>,
+                    > {
                         let cfg = cfg_ref;
                         let initial_symbols = exchange_cfg.symbols.clone();
                         Box::pin(async move {
@@ -79,7 +96,12 @@ pub fn register() {
                                 }
                             }
 
-                            let adapter = LatokenAdapter::new(cfg, client.clone(), global_cfg.chunk_size, symbols);
+                            let adapter = LatokenAdapter::new(
+                                cfg,
+                                client.clone(),
+                                global_cfg.chunk_size,
+                                symbols,
+                            );
 
                             {
                                 let mut set = task_set.lock().await;
@@ -93,7 +115,8 @@ pub fn register() {
 
                             Ok(receivers)
                         })
-                    })
+                    },
+                ),
             );
         }
     });
@@ -147,13 +170,96 @@ impl ExchangeAdapter for LatokenAdapter {
     async fn subscribe(&mut self) -> Result<()> {
         let symbol_refs: Vec<&str> = self.symbols.iter().map(|s| s.as_str()).collect();
         let cfg = stream_config_for_exchange(self.cfg.name);
-        let _chunks = chunk_streams_with_config(&symbol_refs, self.chunk_size, cfg);
-        // Actual subscription logic to LATOKEN would be implemented here.
+        let chunks = chunk_streams_with_config(&symbol_refs, self.chunk_size, cfg);
+
+        for chunk in chunks {
+            let symbols = chunk.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+            let ws_url = self.cfg.ws_base.to_string();
+            let ws_bucket = self.ws_bucket.clone();
+            let shutdown = self.shutdown.clone();
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    ws_bucket.acquire(1).await;
+                    match connect_async(&ws_url).await {
+                        Ok((ws_stream, _)) => {
+                            let (mut write, mut read) = ws_stream.split();
+
+                            for symbol in &symbols {
+                                let sub = serde_json::json!({
+                                    "action": "subscribe",
+                                    "channel": "trades",
+                                    "symbol": symbol
+                                });
+                                let _ = write.send(Message::Text(sub.to_string())).await;
+                                let sub = serde_json::json!({
+                                    "action": "subscribe",
+                                    "channel": "book",
+                                    "symbol": symbol
+                                });
+                                let _ = write.send(Message::Text(sub.to_string())).await;
+                                let sub = serde_json::json!({
+                                    "action": "subscribe",
+                                    "channel": "kline",
+                                    "symbol": symbol,
+                                    "interval": "1m"
+                                });
+                                let _ = write.send(Message::Text(sub.to_string())).await;
+                            }
+
+                            let mut ping_int = interval(Duration::from_secs(30));
+
+                            loop {
+                                tokio::select! {
+                                    msg = read.next() => {
+                                        match msg {
+                                            Some(Ok(Message::Text(txt))) => { let _ = parse_message(&txt); },
+                                            Some(Ok(Message::Ping(p))) => { let _ = write.send(Message::Pong(p)).await; },
+                                            Some(Ok(Message::Close(_))) | None => { break; },
+                        Some(Ok(_)) => {},
+                                            Some(Err(e)) => { tracing::warn!("latoken ws error: {}", e); break; },
+                                        }
+                                    }
+                                    _ = ping_int.tick() => {
+                                        let _ = write.send(Message::Ping(Vec::new())).await;
+                                    }
+                                    _ = async {
+                                        while !shutdown.load(Ordering::Relaxed) {
+                                            sleep(Duration::from_secs(1)).await;
+                                        }
+                                    } => {
+                                        let _ = write.close().await;
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!("latoken connect error: {}", e);
+                        }
+                    }
+                    if shutdown.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    sleep(Duration::from_secs(5)).await;
+                }
+                Ok::<(), anyhow::Error>(())
+            });
+            self.tasks.push(handle);
+        }
         Ok(())
     }
 
     async fn run(&mut self) -> Result<()> {
         self.subscribe().await?;
+        let _ = signal::ctrl_c().await;
+        self.shutdown.store(true, Ordering::SeqCst);
+        for handle in self.tasks.drain(..) {
+            let _ = handle.await;
+        }
         Ok(())
     }
 
@@ -170,3 +276,165 @@ impl ExchangeAdapter for LatokenAdapter {
     }
 }
 
+use core::events::{DepthUpdateEvent, Event, Kline, KlineEvent, StreamMessage, TradeEvent};
+
+pub fn parse_message(text: &str) -> Result<StreamMessage<'static>> {
+    let v: Value = serde_json::from_str(text)?;
+    let topic = v
+        .get("channel")
+        .or_else(|| v.get("topic"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing channel"))?;
+    let symbol = v.get("symbol").and_then(|v| v.as_str()).unwrap_or("");
+    let stream = format!("{}@{}", symbol, topic);
+    match topic {
+        "trades" => {
+            let data = v
+                .get("data")
+                .and_then(|d| d.as_object())
+                .ok_or_else(|| anyhow!("missing data"))?;
+            let price = data
+                .get("price")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let qty = data
+                .get("qty")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let id = data.get("id").and_then(|v| v.as_u64()).unwrap_or(0);
+            let ts = data.get("ts").and_then(|v| v.as_u64()).unwrap_or(0);
+            let side = data.get("side").and_then(|v| v.as_str()).unwrap_or("buy");
+            let trade = TradeEvent {
+                event_time: ts,
+                symbol: symbol.to_string(),
+                trade_id: id,
+                price: price.into(),
+                quantity: qty.into(),
+                buyer_order_id: 0,
+                seller_order_id: 0,
+                trade_time: ts,
+                buyer_is_maker: side.eq_ignore_ascii_case("sell"),
+                best_match: true,
+            };
+            Ok(StreamMessage {
+                stream,
+                data: Event::Trade(trade),
+            })
+        }
+        "book" => {
+            let data = v
+                .get("data")
+                .and_then(|d| d.as_object())
+                .ok_or_else(|| anyhow!("missing data"))?;
+            let bids = data
+                .get("bids")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let asks = data
+                .get("asks")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            let ts = data.get("ts").and_then(|v| v.as_u64()).unwrap_or(0);
+            let seq_start = data.get("seq_start").and_then(|v| v.as_u64()).unwrap_or(0);
+            let seq_end = data.get("seq_end").and_then(|v| v.as_u64()).unwrap_or(0);
+
+            let bids = bids
+                .into_iter()
+                .filter_map(|b| {
+                    let arr = b.as_array()?;
+                    Some([
+                        arr.get(0)?.as_str()?.to_string().into(),
+                        arr.get(1)?.as_str()?.to_string().into(),
+                    ])
+                })
+                .collect();
+            let asks = asks
+                .into_iter()
+                .filter_map(|a| {
+                    let arr = a.as_array()?;
+                    Some([
+                        arr.get(0)?.as_str()?.to_string().into(),
+                        arr.get(1)?.as_str()?.to_string().into(),
+                    ])
+                })
+                .collect();
+
+            let depth = DepthUpdateEvent {
+                event_time: ts,
+                symbol: symbol.to_string(),
+                first_update_id: seq_start,
+                final_update_id: seq_end,
+                previous_final_update_id: seq_start.saturating_sub(1),
+                bids,
+                asks,
+            };
+            Ok(StreamMessage {
+                stream,
+                data: Event::DepthUpdate(depth),
+            })
+        }
+        "kline" => {
+            let data = v
+                .get("data")
+                .and_then(|d| d.as_object())
+                .ok_or_else(|| anyhow!("missing data"))?;
+            let start = data.get("start").and_then(|v| v.as_u64()).unwrap_or(0);
+            let end = data.get("end").and_then(|v| v.as_u64()).unwrap_or(0);
+            let open = data
+                .get("open")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let high = data
+                .get("high")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let low = data
+                .get("low")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let close = data
+                .get("close")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let volume = data
+                .get("volume")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let trades = data.get("trades").and_then(|v| v.as_u64()).unwrap_or(0);
+            let kline = Kline {
+                start_time: start,
+                close_time: end,
+                interval: "1m".to_string(),
+                open: open.into(),
+                close: close.into(),
+                high: high.into(),
+                low: low.into(),
+                volume: volume.into(),
+                trades,
+                is_closed: true,
+                quote_volume: "0".into(),
+                taker_buy_base_volume: "0".into(),
+                taker_buy_quote_volume: "0".into(),
+            };
+            let evt = KlineEvent {
+                event_time: end,
+                symbol: symbol.to_string(),
+                kline,
+            };
+            Ok(StreamMessage {
+                stream,
+                data: Event::Kline(evt),
+            })
+        }
+        _ => Err(anyhow!("unknown topic")),
+    }
+}

--- a/agents/src/adapter/mod.rs
+++ b/agents/src/adapter/mod.rs
@@ -23,14 +23,13 @@ pub trait ExchangeAdapter {
 }
 
 pub mod binance;
-pub mod gateio;
-pub mod lbank;
 pub mod bingx;
-pub mod kucoin;
+pub mod bitget;
+pub mod bitmart;
 pub mod coinex;
 pub mod gateio;
-pub mod xt;
-pub mod bitmart;
-pub mod bitget;
+pub mod kucoin;
 pub mod latoken;
+pub mod lbank;
 pub mod mexc;
+pub mod xt;

--- a/agents/tests/latoken.rs
+++ b/agents/tests/latoken.rs
@@ -1,0 +1,39 @@
+use agents::adapter::latoken::parse_message;
+use arb_core::events::Event;
+
+#[test]
+fn latoken_parse_trade_message() {
+    let json = r#"{
+        "channel":"trades",
+        "symbol":"BTCUSDT",
+        "data":{"id":1,"price":"100.0","qty":"0.5","ts":1,"side":"buy"}
+    }"#;
+    let msg = parse_message(json).unwrap();
+    match msg.data {
+        Event::Trade(t) => {
+            assert_eq!(t.price, "100.0");
+            assert_eq!(t.quantity, "0.5");
+            assert_eq!(t.trade_id, 1);
+        }
+        _ => panic!("expected trade event"),
+    }
+}
+
+#[test]
+fn latoken_parse_depth_message() {
+    let json = r#"{
+        "channel":"book",
+        "symbol":"BTCUSDT",
+        "data":{"bids":[["1","2"]],"asks":[["3","4"]],"ts":1,"seq_start":1,"seq_end":2}
+    }"#;
+    let msg = parse_message(json).unwrap();
+    match msg.data {
+        Event::DepthUpdate(d) => {
+            assert_eq!(d.bids[0][0], "1");
+            assert_eq!(d.asks[0][0], "3");
+            assert_eq!(d.first_update_id, 1);
+            assert_eq!(d.final_update_id, 2);
+        }
+        _ => panic!("expected depth update"),
+    }
+}


### PR DESCRIPTION
## Summary
- implement LATOKEN websocket adapter with trade, book, and kline subscriptions and ping heartbeat
- parse LATOKEN messages into canonical events
- add tests for trade and depth message parsing

## Testing
- `cargo test --package agents latoken`

------
https://chatgpt.com/codex/tasks/task_e_689fcda3dc5083238ae9de4786c9e533