### PR TITLE
Add Bitget websocket adapter with trade and depth tests

### DIFF
--- a/agents/src/adapter/bitget.rs
+++ b/agents/src/adapter/bitget.rs
@@ -1,12 +1,15 @@
 use anyhow::{anyhow, Result};
 use arb_core as core;
 use async_trait::async_trait;
-use core::events::StreamMessage;
-use futures::future::BoxFuture;
+use core::events::{DepthUpdateEvent, Event, Kline, KlineEvent, StreamMessage, TradeEvent};
+use futures::{future::BoxFuture, SinkExt, StreamExt};
 use reqwest::Client;
-use serde_json::Value;
+use serde_json::{json, Value};
+use std::borrow::Cow;
 use std::sync::{Arc, Once};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::{interval, Duration};
+use tokio_tungstenite::{connect_async, tungstenite::protocol::Message};
 use tracing::error;
 
 use super::ExchangeAdapter;
@@ -124,6 +127,7 @@ pub fn register() {
                                 client.clone(),
                                 global_cfg.chunk_size,
                                 symbols,
+                                channels.clone(),
                             );
 
                             {
@@ -147,10 +151,11 @@ pub fn register() {
 
 /// Placeholder adapter for Bitget. Full streaming support is not yet implemented.
 pub struct BitgetAdapter {
-    _cfg: &'static BitgetConfig,
+    cfg: &'static BitgetConfig,
     _client: Client,
     _chunk_size: usize,
-    _symbols: Vec<String>,
+    symbols: Vec<String>,
+    channels: ChannelRegistry,
 }
 
 impl BitgetAdapter {
@@ -159,24 +164,265 @@ impl BitgetAdapter {
         client: Client,
         chunk_size: usize,
         symbols: Vec<String>,
+        channels: ChannelRegistry,
     ) -> Self {
         Self {
-            _cfg: cfg,
+            cfg,
             _client: client,
             _chunk_size: chunk_size,
-            _symbols: symbols,
+            symbols,
+            channels,
         }
     }
+
+    async fn run_symbol(
+        url: String,
+        symbol: String,
+        tx: mpsc::Sender<StreamMessage<'static>>,
+    ) -> Result<()> {
+        let (ws_stream, _) = connect_async(&url).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        let sub = json!({
+            "op": "subscribe",
+            "args": [
+                {"channel": "trade", "instId": symbol},
+                {"channel": "books", "instId": symbol},
+                {"channel": "candle1m", "instId": symbol}
+            ]
+        });
+        write.send(Message::Text(sub.to_string())).await?;
+
+        let write = Arc::new(Mutex::new(write));
+        let ping_writer = write.clone();
+        tokio::spawn(async move {
+            let mut intv = interval(Duration::from_secs(20));
+            loop {
+                intv.tick().await;
+                if ping_writer
+                    .lock()
+                    .await
+                    .send(Message::Text(json!({"op":"ping"}).to_string()))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    if text.contains("ping") {
+                        let _ = write
+                            .lock()
+                            .await
+                            .send(Message::Text(text.replace("ping", "pong")))
+                            .await;
+                        continue;
+                    }
+                    if let Some(ev) = handle_text(&text) {
+                        if tx.send(ev).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                Ok(Message::Ping(p)) => {
+                    let _ = write.lock().await.send(Message::Pong(p)).await;
+                }
+                Ok(Message::Close(_)) | Err(_) => {
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub fn handle_text(text: &str) -> Option<StreamMessage<'static>> {
+    let v: Value = serde_json::from_str(text).ok()?;
+    let channel = v
+        .get("arg")
+        .and_then(|a| a.get("channel"))
+        .and_then(|c| c.as_str())?;
+    match channel {
+        "trade" => parse_trade_frame(&v).ok(),
+        "books" => parse_depth_frame(&v).ok(),
+        "candle1m" => parse_kline_frame(&v).ok(),
+        _ => None,
+    }
+}
+
+pub fn parse_trade_frame(v: &Value) -> Result<StreamMessage<'static>> {
+    let arg = v.get("arg").ok_or_else(|| anyhow!("missing arg"))?;
+    let symbol = arg
+        .get("instId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing instId"))?
+        .to_string();
+    let data = v
+        .get("data")
+        .and_then(|d| d.as_array())
+        .and_then(|a| a.first())
+        .ok_or_else(|| anyhow!("missing data"))?;
+    let price = data.get("price").and_then(|v| v.as_str()).unwrap_or("0");
+    let size = data.get("size").and_then(|v| v.as_str()).unwrap_or("0");
+    let side = data.get("side").and_then(|v| v.as_str()).unwrap_or("");
+    let ts = data
+        .get("ts")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    let event = TradeEvent {
+        event_time: ts,
+        symbol: symbol.clone(),
+        trade_id: 0,
+        price: Cow::Owned(price.to_string()),
+        quantity: Cow::Owned(size.to_string()),
+        buyer_order_id: 0,
+        seller_order_id: 0,
+        trade_time: ts,
+        buyer_is_maker: side.eq_ignore_ascii_case("sell"),
+        best_match: true,
+    };
+    Ok(StreamMessage {
+        stream: format!("{}@trade", symbol),
+        data: Event::Trade(event),
+    })
+}
+
+pub fn parse_depth_frame(v: &Value) -> Result<StreamMessage<'static>> {
+    let arg = v.get("arg").ok_or_else(|| anyhow!("missing arg"))?;
+    let symbol = arg
+        .get("instId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing instId"))?
+        .to_string();
+    let data = v
+        .get("data")
+        .and_then(|d| d.as_array())
+        .and_then(|a| a.first())
+        .ok_or_else(|| anyhow!("missing data"))?;
+    let ts = data
+        .get("ts")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    let mut bids = Vec::new();
+    if let Some(arr) = data.get("bids").and_then(|v| v.as_array()) {
+        for level in arr.iter().filter_map(|l| l.as_array()) {
+            if level.len() >= 2 {
+                bids.push([
+                    Cow::Owned(level[0].as_str().unwrap_or("0").to_string()),
+                    Cow::Owned(level[1].as_str().unwrap_or("0").to_string()),
+                ]);
+            }
+        }
+    }
+    let mut asks = Vec::new();
+    if let Some(arr) = data.get("asks").and_then(|v| v.as_array()) {
+        for level in arr.iter().filter_map(|l| l.as_array()) {
+            if level.len() >= 2 {
+                asks.push([
+                    Cow::Owned(level[0].as_str().unwrap_or("0").to_string()),
+                    Cow::Owned(level[1].as_str().unwrap_or("0").to_string()),
+                ]);
+            }
+        }
+    }
+
+    let event = DepthUpdateEvent {
+        event_time: ts,
+        symbol: symbol.clone(),
+        first_update_id: 0,
+        final_update_id: 0,
+        previous_final_update_id: 0,
+        bids,
+        asks,
+    };
+
+    Ok(StreamMessage {
+        stream: format!("{}@depth", symbol),
+        data: Event::DepthUpdate(event),
+    })
+}
+
+pub fn parse_kline_frame(v: &Value) -> Result<StreamMessage<'static>> {
+    let arg = v.get("arg").ok_or_else(|| anyhow!("missing arg"))?;
+    let symbol = arg
+        .get("instId")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing instId"))?
+        .to_string();
+    let data = v
+        .get("data")
+        .and_then(|d| d.as_array())
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("missing data"))?;
+
+    let start = data
+        .get(0)
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    let open = data.get(1).and_then(|v| v.as_str()).unwrap_or("0");
+    let high = data.get(2).and_then(|v| v.as_str()).unwrap_or("0");
+    let low = data.get(3).and_then(|v| v.as_str()).unwrap_or("0");
+    let close = data.get(4).and_then(|v| v.as_str()).unwrap_or("0");
+    let volume = data.get(5).and_then(|v| v.as_str()).unwrap_or("0");
+
+    let kline = Kline {
+        start_time: start,
+        close_time: start + 60_000,
+        interval: "1m".to_string(),
+        open: Cow::Owned(open.to_string()),
+        close: Cow::Owned(close.to_string()),
+        high: Cow::Owned(high.to_string()),
+        low: Cow::Owned(low.to_string()),
+        volume: Cow::Owned(volume.to_string()),
+        trades: 0,
+        is_closed: true,
+        quote_volume: Cow::Owned("0".to_string()),
+        taker_buy_base_volume: Cow::Owned("0".to_string()),
+        taker_buy_quote_volume: Cow::Owned("0".to_string()),
+    };
+    let event = KlineEvent {
+        event_time: start + 60_000,
+        symbol: symbol.clone(),
+        kline,
+    };
+    Ok(StreamMessage {
+        stream: format!("{}@kline_1m", symbol),
+        data: Event::Kline(event),
+    })
 }
 
 #[async_trait]
 impl super::ExchangeAdapter for BitgetAdapter {
     async fn subscribe(&mut self) -> Result<()> {
+        for symbol in &self.symbols {
+            if let Some(tx) = self.channels.get(&format!("{}:{}", self.cfg.name, symbol)) {
+                let url = "wss://ws.bitget.com/spot/v1/stream?compress=false".to_string();
+                let sym = symbol.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = BitgetAdapter::run_symbol(url, sym, tx).await {
+                        error!("bitget stream error: {}", e);
+                    }
+                });
+            }
+        }
         Ok(())
     }
 
     async fn run(&mut self) -> Result<()> {
-        // Streaming not implemented yet.
+        self.subscribe().await?;
+        futures::future::pending::<()>().await;
         Ok(())
     }
 

--- a/agents/tests/bitget.rs
+++ b/agents/tests/bitget.rs
@@ -1,0 +1,55 @@
+use agents::adapter::bitget::handle_text;
+use arb_core::events::Event;
+use serde_json::json;
+
+#[test]
+fn bitget_parse_trade_and_print() {
+    let raw = r#"{
+        "action":"snapshot",
+        "arg":{"instType":"SP","channel":"trade","instId":"BTCUSDT"},
+        "data":[{"ts":"1620000000000","price":"50000","size":"0.1","side":"buy"}]
+    }"#;
+    if let Some(msg) = handle_text(raw) {
+        if let Event::Trade(ev) = msg.data {
+            assert_eq!(ev.price, "50000");
+            assert_eq!(ev.quantity, "0.1");
+            println!(
+                "{}",
+                json!({
+                    "stream": msg.stream,
+                    "data": {"e":"trade","s":ev.symbol,"p":ev.price,"q":ev.quantity}
+                })
+            );
+        } else {
+            panic!("expected trade");
+        }
+    } else {
+        panic!("no event");
+    }
+}
+
+#[test]
+fn bitget_parse_depth_and_print() {
+    let raw = r#"{
+        "action":"snapshot",
+        "arg":{"instType":"SP","channel":"books","instId":"BTCUSDT"},
+        "data":[{"ts":"1620000000000","bids":[["49900","1"],["49800","2"]],"asks":[["50100","1.5"],["50200","2"]]}]
+    }"#;
+    if let Some(msg) = handle_text(raw) {
+        if let Event::DepthUpdate(ev) = msg.data {
+            assert_eq!(ev.bids.len(), 2);
+            assert_eq!(ev.asks.len(), 2);
+            println!(
+                "{}",
+                json!({
+                    "stream": msg.stream,
+                    "data": {"e":"depthUpdate","s":ev.symbol,"b":ev.bids,"a":ev.asks}
+                })
+            );
+        } else {
+            panic!("expected depth");
+        }
+    } else {
+        panic!("no event");
+    }
+}


### PR DESCRIPTION
## Summary
- implement Bitget websocket adapter with trade, book, and kline parsing
- add unit tests for Bitget trade and order book frames

## Testing
- `cargo test --package agents bitget`
- `API_KEY=demo API_SECRET=demo SPOT_SYMBOLS=ALL FUTURES_SYMBOLS=ALL cargo run --bin ingestor -- --exchanges bitget --symbols BTCUSDT` *(fails: Unknown TLS backend passed to `use_preconfigured_tls`)*

------
https://chatgpt.com/codex/tasks/task_e_689fcd7854a483239bfd6d394bbc9278