### PR TITLE
Align adapter endpoints and add streaming for Bitget/BitMart

### DIFF
--- a/agents/src/adapter/bingx.rs
+++ b/agents/src/adapter/bingx.rs
@@ -31,14 +31,14 @@ pub const BINGX_EXCHANGES: &[BingxConfig] = &[
         id: "bingx_spot",
         name: "BingX Spot",
         info_url: "https://open-api.bingx.com/openApi/spot/v1/common/symbols",
-        ws_base: "wss://open-api-ws.bingx.com/market",
+        ws_base: "wss://open-api-ws.bingx.com/",
         market: MarketType::Spot,
     },
     BingxConfig {
         id: "bingx_swap",
         name: "BingX Swap",
         info_url: "https://open-api.bingx.com/openApi/swap/v2/market/symbolList",
-        ws_base: "wss://open-api-ws.bingx.com/market",
+        ws_base: "wss://open-api-ws.bingx.com/",
         market: MarketType::Swap,
     },
 ];

--- a/agents/src/adapter/lbank.rs
+++ b/agents/src/adapter/lbank.rs
@@ -26,7 +26,7 @@ pub struct LbankConfig {
 pub const LBANK_EXCHANGES: &[LbankConfig] = &[LbankConfig {
     id: "lbank_spot",
     name: "LBank",
-    ws_base: "wss://api.lbkex.com/ws",
+    ws_base: "wss://www.lbkex.net/ws/",
 }];
 
 const SPOT_URL: &str = "https://api.lbkex.com/v2/currencyPairs.do";

--- a/agents/src/adapter/mexc.rs
+++ b/agents/src/adapter/mexc.rs
@@ -38,7 +38,7 @@ pub const MEXC_EXCHANGES: &[MexcConfig] = &[MexcConfig {
     id: "mexc_spot",
     name: "MEXC Spot",
     info_url: "https://api.mexc.com/api/v3/exchangeInfo",
-    ws_base: "wss://wbs.mexc.com/ws",
+    ws_base: "wss://wbs-api.mexc.com/ws",
 }];
 
 /// Retrieve all trading symbols for MEXC using its `exchangeInfo` endpoint.


### PR DESCRIPTION
## Summary
- update MEXC, BingX, LBank and XT adapters to latest websocket endpoints
- add websocket streaming loops for Bitget and BitMart adapters

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689fd3e49f4083238cb2247052b68e74