### PR TITLE
Add kline subscription for CoinEx streams

### DIFF
--- a/agents/src/adapter/coinex.rs
+++ b/agents/src/adapter/coinex.rs
@@ -239,7 +239,15 @@ impl ExchangeAdapter for CoinexAdapter {
                                     "id": 0,
                                 });
                                 let _ = ws.send(Message::Text(sub.to_string())).await;
+                                let sub = serde_json::json!({
+                                    "method": "kline.subscribe",
+                                    "params": [symbol, 60],
+                                    "id": 0,
+                                });
+                                let _ = ws.send(Message::Text(sub.to_string())).await;
                             }
+                            let topics = symbols.len() * 4;
+                            tracing::info!("subscribed {topics} topics to {ws_url}");
                             loop {
                                 tokio::select! {
                                     msg = ws.next() => {

--- a/streams_coinex_perpetual.json
+++ b/streams_coinex_perpetual.json
@@ -3,6 +3,7 @@
   "per_symbol": [
     "depth.subscribe",
     "deals.subscribe",
-    "state.subscribe"
+    "state.subscribe",
+    "kline.subscribe"
   ]
 }

--- a/streams_coinex_spot.json
+++ b/streams_coinex_spot.json
@@ -3,6 +3,7 @@
   "per_symbol": [
     "depth.subscribe",
     "deals.subscribe",
-    "state.subscribe"
+    "state.subscribe",
+    "kline.subscribe"
   ]
 }


### PR DESCRIPTION
## Summary
- subscribe to CoinEx 1m kline streams and log topic counts
- include kline streams in CoinEx spot and perpetual configs

## Testing
- `cargo test -p agents`

------
https://chatgpt.com/codex/tasks/task_e_689fdc0d7b5883239df0772018583302