### PR TITLE
Require client param for Gate.io symbol fetch

### DIFF
--- a/agents/src/adapter/gateio.rs
+++ b/agents/src/adapter/gateio.rs
@@ -37,9 +37,10 @@ pub const GATEIO_EXCHANGES: &[GateioConfig] = &[
     },
 ];
 
-/// Retrieve all trading symbols for Gate.io across market types.
-pub async fn fetch_symbols(cfg: &GateioConfig) -> Result<Vec<String>> {
-    let client = Client::new();
+/// Retrieve all trading symbols for Gate.io across market types using the provided HTTP client.
+///
+/// The caller must supply a reusable [`reqwest::Client`] instance for efficiency.
+pub async fn fetch_symbols(client: &Client, cfg: &GateioConfig) -> Result<Vec<String>> {
     let mut result: Vec<String> = Vec::new();
     let limit = 100u32;
 
@@ -146,7 +147,7 @@ pub fn register() {
                         Box::pin(async move {
                             let mut symbols = initial_symbols;
                             if symbols.is_empty() {
-                                symbols = fetch_symbols(cfg).await?;
+                                symbols = fetch_symbols(&client, cfg).await?;
                             }
 
                             let mut receivers = Vec::new();

--- a/agents/tests/gateio.rs
+++ b/agents/tests/gateio.rs
@@ -1,4 +1,5 @@
 use agents::adapter::gateio::{fetch_symbols, GateioConfig};
+use reqwest::Client;
 
 #[tokio::test]
 #[ignore]
@@ -10,6 +11,7 @@ async fn fetch_symbols_returns_pairs() {
         info_url: INFO_URL,
         ws_base: "",
     };
-    let symbols = fetch_symbols(&cfg).await.unwrap();
+    let client = Client::new();
+    let symbols = fetch_symbols(&client, &cfg).await.unwrap();
     assert!(!symbols.is_empty());
 }


### PR DESCRIPTION
## Summary
- accept a `reqwest::Client` reference in `gateio::fetch_symbols`
- pass the configured client during Gate.io adapter registration and in tests

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689febc4cedc8323b91f1c09350c0604