### PR TITLE
Register LBank adapter

### DIFF
--- a/agents/src/lib.rs
+++ b/agents/src/lib.rs
@@ -123,6 +123,7 @@ pub async fn spawn_adapters(
     adapter::bitmart::register();
     adapter::coinex::register();
     adapter::latoken::register();
+    adapter::lbank::register();
     adapter::bitget::register();
 
     let mut receivers = Vec::new();


### PR DESCRIPTION
## Summary
- register LBank adapter so it can be spawned via registry

## Testing
- `cargo test -p agents`


------
https://chatgpt.com/codex/tasks/task_e_689ff19a8d1883239201ab8c10aac4ac