### PR TITLE
feat: add candles to kucoin futures streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This project connects to the Binance.US, Binance.com (global), Binance Futures, 
 - **CoinEx Spot & Perpetual:** `depth.subscribe`, `deals.subscribe`, `state.subscribe`, `kline.subscribe`
 - **Gate.io Spot/Futures:** `order_book_update`, `trades`, `tickers`
 - **KuCoin Spot:** global `/market/ticker:all`, `/market/snapshot:all`; per-symbol `/market/ticker`, `/market/snapshot`, `/market/level2`, `/market/level2Depth5`, `/market/level2Depth50`, `/market/match`
-- **KuCoin Futures:** global `/contractMarket/ticker:all`; per-symbol `/contractMarket/ticker`, `/contractMarket/level2`, `/contractMarket/level2Depth5`, `/contractMarket/level2Depth50`, `/contractMarket/execution`, `/contractMarket/tradeOrders`, `/contractMarket/indexPrice`, `/contractMarket/markPrice`, `/contractMarket/fundingRate`
+- **KuCoin Futures:** global `/contractMarket/ticker:all`; per-symbol `/contractMarket/ticker`, `/contractMarket/level2`, `/contractMarket/level2Depth5`, `/contractMarket/level2Depth50`, `/contractMarket/execution`, `/contractMarket/indexPrice`, `/contractMarket/markPrice`, `/contractMarket/fundingRate`, `/contractMarket/candles:*`
 - **Latoken:** `trades`, `ticker`, `orderbook`
 - **LBank:** `ticker`, `trade`, `depth`, `kline_1m`, `kline_3m`, `kline_5m`, `kline_15m`, `kline_30m`, `kline_1h`, `kline_2h`, `kline_4h`, `kline_6h`, `kline_12h`, `kline_1d`, `kline_1w`, `kline_1M`
 - **XT:** `depth`, `trade`, `kline`

--- a/agents/src/adapter/kucoin.rs
+++ b/agents/src/adapter/kucoin.rs
@@ -149,11 +149,25 @@ impl KucoinAdapter {
         let (mut write, mut read) = ws_stream.split();
 
         for symbol in &self.symbols {
-            let topics = [
-                format!("/market/match:{}", symbol),
-                format!("/market/level2:{}", symbol),
-                format!("/market/candles:1min:{}", symbol),
-            ];
+            let topics: Vec<String> = if self.cfg.id.contains("futures") {
+                vec![
+                    format!("/contractMarket/ticker:{}", symbol),
+                    format!("/contractMarket/level2:{}", symbol),
+                    format!("/contractMarket/level2Depth5:{}", symbol),
+                    format!("/contractMarket/level2Depth50:{}", symbol),
+                    format!("/contractMarket/execution:{}", symbol),
+                    format!("/contractMarket/indexPrice:{}", symbol),
+                    format!("/contractMarket/markPrice:{}", symbol),
+                    format!("/contractMarket/fundingRate:{}", symbol),
+                    format!("/contractMarket/candles:1min:{}", symbol),
+                ]
+            } else {
+                vec![
+                    format!("/market/match:{}", symbol),
+                    format!("/market/level2:{}", symbol),
+                    format!("/market/candles:1min:{}", symbol),
+                ]
+            };
             for topic in topics {
                 let msg = json!({
                     "id": Uuid::new_v4().to_string(),

--- a/streams_kucoin_futures.json
+++ b/streams_kucoin_futures.json
@@ -8,9 +8,9 @@
     "/contractMarket/level2Depth5",
     "/contractMarket/level2Depth50",
     "/contractMarket/execution",
-    "/contractMarket/tradeOrders",
     "/contractMarket/indexPrice",
     "/contractMarket/markPrice",
-    "/contractMarket/fundingRate"
+    "/contractMarket/fundingRate",
+    "/contractMarket/candles:*"
   ]
 }


### PR DESCRIPTION
## Summary
- add candle subscription to KuCoin futures streams
- remove tradeOrders from KuCoin futures stream config and README
- update KuCoin adapter to use new candle topics

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689ff9a280048323827e539e8ab4d67e