### PR TITLE
Add Gate.io message structs and conversions

### DIFF
--- a/canonical/Cargo.toml
+++ b/canonical/Cargo.toml
@@ -7,6 +7,4 @@ edition = "2021"
 arb_core = { path = "../core" }
 rust_decimal = "1"
 serde = { version = "1", features = ["derive"] }
-
-[dev-dependencies]
 serde_json = "1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = "0.10"
 hex = "0.4"
 rust_decimal = "1"
 tracing = "0.1"
+serde_json = "1"
 
 [features]
 default = []

--- a/core/src/events.rs
+++ b/core/src/events.rs
@@ -534,6 +534,50 @@ pub struct MexcBookTicker<'a> {
     pub ask_qty: Cow<'a, str>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GateioStreamMessage<'a> {
+    pub method: &'a str,
+    pub params: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GateioTrade<'a> {
+    pub id: u64,
+    #[serde(rename = "create_time_ms")]
+    pub create_time_ms: u64,
+    pub price: Cow<'a, str>,
+    pub amount: Cow<'a, str>,
+    pub side: Cow<'a, str>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GateioDepth<'a> {
+    #[serde(rename = "t")]
+    pub timestamp: u64,
+    pub bids: Vec<[Cow<'a, str>; 2]>,
+    pub asks: Vec<[Cow<'a, str>; 2]>,
+    #[serde(default)]
+    pub id: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GateioKline<'a> {
+    #[serde(rename = "t")]
+    pub timestamp: u64,
+    #[serde(rename = "o")]
+    pub open: Cow<'a, str>,
+    #[serde(rename = "c")]
+    pub close: Cow<'a, str>,
+    #[serde(rename = "h")]
+    pub high: Cow<'a, str>,
+    #[serde(rename = "l")]
+    pub low: Cow<'a, str>,
+    #[serde(rename = "v")]
+    pub volume: Cow<'a, str>,
+}
+
 impl<'a> TradeEvent<'a> {
     pub fn channel(&self) -> Channel {
         Channel::Trade


### PR DESCRIPTION
## Summary
- add Gate.io websocket message structs
- convert Gate.io trade, depth, and kline updates into canonical market data events
- test conversions using sample Gate.io payloads

## Testing
- `cargo test -p canonical`


------
https://chatgpt.com/codex/tasks/task_e_68a0026ea5f48323990b6d411307c381