### PR TITLE
Remove unused order book fields for LATOKEN and MEXC adapters

### DIFF
--- a/agents/src/adapter/latoken.rs
+++ b/agents/src/adapter/latoken.rs
@@ -5,7 +5,6 @@ use arb_core as core;
 use async_trait::async_trait;
 use core::rate_limit::TokenBucket;
 use core::{chunk_streams_with_config, stream_config_for_exchange};
-use dashmap::DashMap;
 use futures::{future::BoxFuture, SinkExt, StreamExt};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -124,7 +123,6 @@ pub struct LatokenAdapter {
     _client: Client,
     chunk_size: usize,
     symbols: Vec<String>,
-    _books: Arc<DashMap<String, core::OrderBook>>,
     http_bucket: Arc<TokenBucket>,
     ws_bucket: Arc<TokenBucket>,
     tasks: Vec<JoinHandle<Result<()>>>,
@@ -144,7 +142,6 @@ impl LatokenAdapter {
             _client: client,
             chunk_size,
             symbols,
-            _books: Arc::new(DashMap::new()),
             http_bucket: Arc::new(TokenBucket::new(
                 global_cfg.http_burst,
                 global_cfg.http_refill_per_sec,

--- a/agents/src/adapter/mexc.rs
+++ b/agents/src/adapter/mexc.rs
@@ -2,8 +2,7 @@ use anyhow::{anyhow, Result};
 use arb_core as core;
 use async_trait::async_trait;
 use core::rate_limit::TokenBucket;
-use core::{chunk_streams_with_config, stream_config_for_exchange, OrderBook};
-use dashmap::DashMap;
+use core::{chunk_streams_with_config, stream_config_for_exchange};
 use futures::{SinkExt, StreamExt};
 use reqwest::Client;
 use serde_json::Value;
@@ -148,7 +147,6 @@ pub struct MexcAdapter {
     _client: Client,
     chunk_size: usize,
     symbols: Vec<String>,
-    _books: Arc<DashMap<String, OrderBook>>,
     http_bucket: Arc<TokenBucket>,
     ws_bucket: Arc<TokenBucket>,
     tasks: Vec<JoinHandle<Result<()>>>,
@@ -168,7 +166,6 @@ impl MexcAdapter {
             _client: client,
             chunk_size,
             symbols,
-            _books: Arc::new(DashMap::new()),
             http_bucket: Arc::new(TokenBucket::new(
                 global_cfg.http_burst,
                 global_cfg.http_refill_per_sec,


### PR DESCRIPTION
## Summary
- trim unused order book tracking fields from LATOKEN adapter
- trim unused order book tracking fields from MEXC adapter

## Testing
- `cargo test -p agents` *(fails: expected `;`, found keyword `let` in agents/src/adapter/bitmart.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a13172fe5483239c5b4d579beb0590