### PR TITLE
Handle TokenBucket closure errors

### DIFF
--- a/agents/src/adapter/binance.rs
+++ b/agents/src/adapter/binance.rs
@@ -452,7 +452,9 @@ async fn reconnect_loop<F, Fut, S>(
         .unwrap_or(10);
 
     loop {
-        ws_bucket.acquire(1).await;
+        if ws_bucket.acquire(1).await.is_err() {
+            break;
+        }
         tracing::info!(
             "\u{2192} opening WS ({}): {} ({} streams)",
             name,
@@ -520,7 +522,7 @@ async fn rate_limited_get(
     let mut backoff = Duration::from_secs(1);
     let max_backoff = Duration::from_secs(64);
     loop {
-        bucket.acquire(1).await;
+        bucket.acquire(1).await?;
         match client.get(url).send().await {
             Ok(resp) => {
                 if resp.status() == StatusCode::TOO_MANY_REQUESTS {

--- a/agents/src/adapter/coinex.rs
+++ b/agents/src/adapter/coinex.rs
@@ -230,7 +230,9 @@ impl ExchangeAdapter for CoinexAdapter {
                     if shutdown.load(Ordering::Relaxed) {
                         break;
                     }
-                    ws_bucket.acquire(1).await;
+                    if ws_bucket.acquire(1).await.is_err() {
+                        break;
+                    }
                     match connect_async(&ws_url).await {
                         Ok((mut ws, _)) => {
                             for symbol in &symbols {
@@ -364,7 +366,7 @@ impl ExchangeAdapter for CoinexAdapter {
     }
 
     async fn backfill(&mut self) -> Result<()> {
-        self.http_bucket.acquire(1).await;
+        self.http_bucket.acquire(1).await?;
         Ok(())
     }
 }

--- a/agents/src/adapter/mexc.rs
+++ b/agents/src/adapter/mexc.rs
@@ -200,7 +200,9 @@ impl ExchangeAdapter for MexcAdapter {
                     if shutdown.load(Ordering::Relaxed) {
                         break;
                     }
-                    ws_bucket.acquire(1).await;
+                    if ws_bucket.acquire(1).await.is_err() {
+                        break;
+                    }
                     match connect_async(&ws_url).await {
                         Ok((mut ws, _)) => {
                             let params: Vec<String> = symbols
@@ -291,7 +293,7 @@ impl ExchangeAdapter for MexcAdapter {
 
     async fn backfill(&mut self) -> Result<()> {
         // Placeholder for potential REST snapshot calls respecting HTTP rate limits
-        self.http_bucket.acquire(1).await;
+        self.http_bucket.acquire(1).await?;
         Ok(())
     }
 }

--- a/agents/src/adapter/xt.rs
+++ b/agents/src/adapter/xt.rs
@@ -211,7 +211,9 @@ impl ExchangeAdapter for XtAdapter {
                     if shutdown.load(Ordering::Relaxed) {
                         break;
                     }
-                    ws_bucket.acquire(1).await;
+                    if ws_bucket.acquire(1).await.is_err() {
+                        break;
+                    }
                     match connect_async(&ws_url).await {
                         Ok((mut ws, _)) => {
                             let sub = serde_json::json!({
@@ -291,7 +293,7 @@ impl ExchangeAdapter for XtAdapter {
     }
 
     async fn backfill(&mut self) -> Result<()> {
-        self.http_bucket.acquire(1).await;
+        self.http_bucket.acquire(1).await?;
         Ok(())
     }
 }

--- a/agents/tests/network.rs
+++ b/agents/tests/network.rs
@@ -102,7 +102,7 @@ async fn subscribe_handles_reconnect_failures() {
 #[tokio::test]
 async fn token_bucket_enforces_rate_limit() {
     let bucket = TokenBucket::new(1, 0, Duration::from_secs(60));
-    bucket.acquire(1).await;
+    bucket.acquire(1).await.unwrap();
     let fut = bucket.acquire(1);
     assert!(tokio::time::timeout(Duration::from_millis(50), fut)
         .await

--- a/core/benches/rate_limit.rs
+++ b/core/benches/rate_limit.rs
@@ -83,7 +83,7 @@ fn bench_semaphore_bucket(c: &mut Criterion) {
     c.bench_function("semaphore_bucket", |b| {
         let bucket = bucket.clone();
         b.to_async(&rt).iter(|| async {
-            bucket.acquire(1).await;
+            bucket.acquire(1).await.unwrap();
         });
     });
 }

--- a/core/tests/rate_limit.rs
+++ b/core/tests/rate_limit.rs
@@ -6,6 +6,7 @@ async fn acquire_clamps_to_capacity() {
     let bucket = TokenBucket::new(5, 0, Duration::from_secs(1));
     tokio::time::timeout(Duration::from_secs(1), bucket.acquire(10))
         .await
-        .expect("acquire should not time out");
+        .expect("acquire should not time out")
+        .unwrap();
     assert_eq!(bucket.available(), 0);
 }


### PR DESCRIPTION
## Summary
- close token bucket semaphore before aborting background refill task
- make `TokenBucket::acquire` return `Result` and propagate `AcquireError`
- update call sites and tests for new result type

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a13e41c9ec8323b8ff9f45955bba13