### PR TITLE
test: verify binance fetch_symbols client reuse

### DIFF
--- a/agents/Cargo.toml
+++ b/agents/Cargo.toml
@@ -33,6 +33,7 @@ criterion = { version = "0.5", default-features = false, features = ["async_toki
 metrics-util = "0.20"
 httpmock = "0.6"
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
+hyper = { version = "0.14", features = ["server", "http1"] }
 
 [[bench]]
 name = "orderbook_update"


### PR DESCRIPTION
## Summary
- add dev dependency on hyper for tests
- test that repeated Binance `fetch_symbols` calls reuse the reqwest client by counting connections

## Testing
- `cargo test -p agents`

------
https://chatgpt.com/codex/tasks/task_e_68a150418a848323867edc6b9a380c02