### PR TITLE
Use saturating_mul for backoff calculation

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -201,7 +201,7 @@ pub fn next_backoff(
     if was_successful && run_duration >= min_stable {
         Duration::from_secs(1)
     } else {
-        std::cmp::min(previous * 2, max_backoff)
+        std::cmp::min(previous.saturating_mul(2), max_backoff)
     }
 }
 

--- a/core/tests/backoff.rs
+++ b/core/tests/backoff.rs
@@ -27,3 +27,19 @@ fn backoff_resets_after_stable_run() {
     );
     assert_eq!(backoff, Duration::from_secs(1));
 }
+
+#[test]
+fn backoff_handles_large_previous_without_overflow() {
+    let max_backoff = Duration::from_secs(64);
+    let min_stable = Duration::from_secs(5);
+
+    let backoff = next_backoff(
+        Duration::MAX,
+        Duration::from_secs(0),
+        false,
+        max_backoff,
+        min_stable,
+    );
+
+    assert_eq!(backoff, max_backoff);
+}


### PR DESCRIPTION
## Summary
- Prevent overflow in `next_backoff` by using `Duration::saturating_mul`
- Add regression test for large previous backoff values

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a155f7d93c8323a3dacba053e44c0d