### PR TITLE
Trim parse_list_env entries and drop empties

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -144,14 +144,9 @@ fn parse_list_env(var: &str) -> Vec<String> {
     env::var(var)
         .unwrap_or_default()
         .split(',')
-        .filter_map(|s| {
-            let trimmed = s.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        })
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
         .collect()
 }
 


### PR DESCRIPTION
## Summary
- Trim entries in `parse_list_env` and discard empty items

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a15d0dec5c83239d6dc9dfb48f3205