### PR TITLE
Log events only at INFO level

### DIFF
--- a/ingestor/src/main.rs
+++ b/ingestor/src/main.rs
@@ -8,7 +8,7 @@ use tokio::{
     sync::{mpsc, Mutex},
     task::JoinSet,
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, Level};
 use tracing_subscriber::EnvFilter;
 
 use agents::{spawn_adapters, TaskSet};
@@ -40,8 +40,10 @@ fn build_client(cfg: &config::Config, tls_config: Arc<ClientConfig>) -> Result<C
 }
 
 async fn forward_event(ev: MdEvent) -> Result<()> {
-    let json = serde_json::to_string(&ev).context("serializing MdEvent")?;
-    info!(event = %json, "forwarded md event");
+    if tracing::enabled!(Level::INFO) {
+        let json = serde_json::to_string(&ev).context("serializing MdEvent")?;
+        info!(event = %json, "forwarded md event");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Avoid serializing and logging market data events when info level is disabled

## Testing
- `cargo test -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68a15ef311cc8323b0e91734945fafb0