### PR TITLE
Retry Binance HTTP requests on errors

### DIFF
--- a/agents/src/adapter/binance.rs
+++ b/agents/src/adapter/binance.rs
@@ -532,7 +532,12 @@ async fn rate_limited_get(
                 }
                 return resp.error_for_status().map_err(|e| e.into());
             }
-            Err(e) => return Err(e.into()),
+            Err(e) => {
+                tracing::warn!("Request error for {}: {}", url, e);
+                sleep(backoff).await;
+                backoff = std::cmp::min(backoff * 2, max_backoff);
+                continue;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- retry Binance REST calls after request failures with exponential backoff

## Testing
- `cargo test -p agents`


------
https://chatgpt.com/codex/tasks/task_e_68a1659920d88323bb2b2fe1d25e4a26