### PR TITLE
Use saturating_mul for backoff and test large previous values

### DIFF
--- a/agents/src/adapter/binance.rs
+++ b/agents/src/adapter/binance.rs
@@ -500,7 +500,7 @@ async fn reconnect_loop<F, Fut, S>(
         if connected {
             backoff = next_backoff(backoff, elapsed, ok, max_backoff, min_stable);
         } else {
-            backoff = std::cmp::min(backoff * 2, max_backoff);
+            backoff = std::cmp::min(backoff.saturating_mul(2), max_backoff);
         }
 
         let jitter: f32 = rand::thread_rng().gen_range(0.8..1.2);
@@ -527,7 +527,7 @@ async fn rate_limited_get(
                 if resp.status() == StatusCode::TOO_MANY_REQUESTS {
                     tracing::warn!("HTTP 429 for {}", url);
                     sleep(backoff).await;
-                    backoff = std::cmp::min(backoff * 2, max_backoff);
+                    backoff = std::cmp::min(backoff.saturating_mul(2), max_backoff);
                     continue;
                 }
                 return resp.error_for_status().map_err(|e| e.into());
@@ -535,7 +535,7 @@ async fn rate_limited_get(
             Err(e) => {
                 tracing::warn!("Request error for {}: {}", url, e);
                 sleep(backoff).await;
-                backoff = std::cmp::min(backoff * 2, max_backoff);
+                backoff = std::cmp::min(backoff.saturating_mul(2), max_backoff);
                 continue;
             }
         }

--- a/core/tests/backoff.rs
+++ b/core/tests/backoff.rs
@@ -43,3 +43,20 @@ fn backoff_handles_large_previous_without_overflow() {
 
     assert_eq!(backoff, max_backoff);
 }
+
+#[test]
+fn backoff_handles_previous_near_overflow() {
+    let max_backoff = Duration::from_secs(64);
+    let min_stable = Duration::from_secs(5);
+
+    let large_previous = Duration::from_secs(u64::MAX / 2 + 1);
+    let backoff = next_backoff(
+        large_previous,
+        Duration::from_secs(0),
+        false,
+        max_backoff,
+        min_stable,
+    );
+
+    assert_eq!(backoff, max_backoff);
+}

--- a/ingestor/src/main.rs
+++ b/ingestor/src/main.rs
@@ -78,7 +78,7 @@ async fn process_stream_event<F, Fut>(
                             "failed to forward event, retrying",
                         );
                         sleep(delay).await;
-                        delay = std::cmp::min(delay * 2, max_delay);
+                        delay = std::cmp::min(delay.saturating_mul(2), max_delay);
                     }
                     Err(e) => {
                         error!(error = %e, "failed to forward event, giving up");


### PR DESCRIPTION
## Summary
- avoid Duration overflow by using `saturating_mul` when doubling backoff or delay
- add regression test covering very large previous backoff values

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a16a0fd0108323b48f5ba541554463