### PR TITLE
Log MdEvent normalization errors

### DIFF
--- a/ingestor/src/main.rs
+++ b/ingestor/src/main.rs
@@ -87,8 +87,8 @@ async fn process_stream_event<F, Fut>(
                 }
             }
         }
-        Err(_) => {
-            error!(stream = %msg.stream, "failed to normalize event");
+        Err(e) => {
+            error!(error = %format!("{:?}", e), stream = %msg.stream, "failed to normalize event");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Log errors returned when MdEvent::try_from fails

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a16c85edc0832389a64db9bacfa444