### PR TITLE
Clone TLS configuration in ingestor HTTP client

### DIFF
--- a/ingestor/src/main.rs
+++ b/ingestor/src/main.rs
@@ -40,7 +40,8 @@ fn build_client(cfg: &config::Config, tls_config: Arc<ClientConfig>) -> Result<C
     let mut client_builder = Client::builder()
         .timeout(Duration::from_secs(cfg.http_timeout_secs))
         .user_agent(user_agent)
-        .use_preconfigured_tls(tls_config);
+        // Clone the underlying TLS config so reqwest receives a concrete `ClientConfig`
+        .use_preconfigured_tls(tls_config.as_ref().clone());
     if let Some(proxy) = cfg.proxy_url.as_ref().filter(|p| !p.is_empty()) {
         client_builder = client_builder
             .proxy(Proxy::all(format!("socks5h://{proxy}")).context("invalid proxy URL")?);


### PR DESCRIPTION
## Summary
- Clone the underlying `rustls::ClientConfig` before passing it to `reqwest`
- Document the rationale for cloning the TLS config

## Testing
- `SPOT_SYMBOLS=ALL FUTURES_SYMBOLS=ALL MD_SINK_FILE=output.jsonl API_KEY=[redacted] API_SECRET=[redacted] RUST_LOG=info timeout 5s cargo run -p ingestor`


------
https://chatgpt.com/codex/tasks/task_e_68a5177112f083238f5baef39477a872